### PR TITLE
Fix displaying the group name in the tree when creating a group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tab-group",
-	"version": "1.0.0",
+	"version": "2.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tab-group",
-			"version": "1.0.0",
+			"version": "2.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jest": "^29.1.2",

--- a/src/TreeDataProvider.ts
+++ b/src/TreeDataProvider.ts
@@ -129,6 +129,7 @@ export class TreeDataProvider extends Disposable implements vscode.TreeDataProvi
 					vscode.window.showInputBox({ placeHolder: 'Name this Group' }).then(input => {
 						if (input) {
 							this.treeData.renameGroup(group, input);
+							this.triggerRerender();
 						}
 					});
 				}


### PR DESCRIPTION
This PR fixes the issue when we are creating a new tab group in the tree view and adding a name to it, that name was not displayed in the tree view.

Trigger a rerender after setting the name will fix this issue.