### PR TITLE
Add close all tabs in a group functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
 				"icon": "$(array)"
 			},
 			{
+				"command": "tabsTreeView.group.close",
+				"title": "Close all Tabs in this Group",
+				"icon": "$(close)"
+			},
+			{
 				"command": "tabsTreeView.enableSortMode",
 				"title": "Sort Mode",
 				"icon": "$(selection)"
@@ -121,6 +126,11 @@
 					"command": "tabsTreeView.group.cancelGroup",
 					"when": "view =~ /^tabsTreeView/ && viewItem == 'group'",
 					"group": "inline@1"
+				},
+				{
+					"command": "tabsTreeView.group.close",
+					"when": "view =~ /^tabsTreeView/ && viewItem == 'group'",
+					"group": "inline@2"
 				}
 			],
 			"view/title": [

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 			},
 			{
 				"command": "tabsTreeView.group.close",
-				"title": "Close all Tabs in this Group",
+				"title": "Close Grouped Tabs",
 				"icon": "$(close)"
 			},
 			{

--- a/src/TreeView.ts
+++ b/src/TreeView.ts
@@ -41,6 +41,10 @@ export class TabsView extends Disposable {
 		}));
 		
 		this._register(vscode.commands.registerCommand('tabsTreeView.group.cancelGroup', (group: Group) => this.treeDataProvider.cancelGroup(group)));
+
+		this._register(vscode.commands.registerCommand('tabsTreeView.group.close', (group: Group) => {
+			vscode.window.tabGroups.close(group.children.map((tab: Tab) => getNativeTabs(tab)).flat());
+		}));
 		
 		this._register(vscode.commands.registerCommand('tabsTreeView.reset', () => {
 			WorkspaceState.setState([]);


### PR DESCRIPTION
This PR adds functionality to a Tab Group to close all the Tabs within that Group.
The functionality can be can be executed by clicking on the close icon of a Group in the tree:
![image](https://github.com/billgoo/vscode-tab-group/assets/12937644/a36c0f01-6c15-40fb-8db0-e234bee0b6e7)
