### PR TITLE
Set existing group name in the rename input field

### DIFF
--- a/src/TreeView.ts
+++ b/src/TreeView.ts
@@ -33,7 +33,7 @@ export class TabsView extends Disposable {
 		this._register(vscode.commands.registerCommand('tabsTreeView.tab.ungroup', (tab: Tab) => this.treeDataProvider.ungroup(tab)));
 		
 		this._register(vscode.commands.registerCommand('tabsTreeView.group.rename', (group: Group) => {
-			vscode.window.showInputBox({ placeHolder: 'Name this Group' }).then(input => {
+			vscode.window.showInputBox({ placeHolder: 'Name this Group', value: group.label }).then(input => {
 				if (input) {
 					this.treeDataProvider.renameGroup(group, input);
 				}


### PR DESCRIPTION
This PR adds a small improvement to the group renaming. We will set the existing Group name in the rename input field when we rename a Group.