### PR TITLE
Improve group color usage

### DIFF
--- a/src/TreeData.ts
+++ b/src/TreeData.ts
@@ -86,6 +86,10 @@ export class TreeData {
 		tab.groupId = null;
 	}
 
+	private _getUsedColorIds(): string[] {
+		return Object.values(this.groupMap).map(group => group.colorId)
+	};
+
 	public group(target: Tab | Group, tabs: Tab[]) {
 		if (tabs.length === 0) {
 			return;
@@ -105,7 +109,7 @@ export class TreeData {
 
 		const group: Group = {
 			type: TreeItemType.Group,
-			colorId: getNextColorId(),
+			colorId: getNextColorId(this._getUsedColorIds()),
 			id: randomUUID(),
 			label: '',
 			children: [],

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,6 +1,3 @@
-
-let index = 0;
-
 const colorIds = [
 	"charts.foreground",
 	"charts.lines",
@@ -12,7 +9,9 @@ const colorIds = [
 	"charts.purple",
 ];
 
-export function getNextColorId(): string {
-	index = (index + 1) % colorIds.length;
-	return colorIds[index];
+export function getNextColorId(usedColorIds: string[] = []): string {
+	const colorIdsUseCount = colorIds.map(colorId => usedColorIds.filter(usedColorId => usedColorId === colorId).length);
+	const smallestUseCount = Math.min(...colorIdsUseCount);
+	const firstSmallestUseCountIndex = colorIdsUseCount.indexOf(smallestUseCount);
+	return colorIds[firstSmallestUseCountIndex];
 }


### PR DESCRIPTION
This PR improves the group coloring.

The current behaviour of selecting group color when we are creating a group: we are increasing an index and get the item with this index from a color array. If we create a group, then ungroup it and create a group again, the group color will be different because the index was increased in the background.

With this improvement we are checking which colors were used and how many times. The next color will be the first from the color array which was used the fewest times.