### PR TITLE
Prevent orphaned diff tabs

### DIFF
--- a/src/TabTypeHandler.ts
+++ b/src/TabTypeHandler.ts
@@ -127,9 +127,14 @@ export class TabInputTextDiffHandler implements TabTypeHandler<vscode.TabInputTe
 	}
 
 	getNormalizedId(tab: TypedTab<vscode.TabInputTextDiff>): string {
+		const serializeUri = (uri: vscode.Uri) => {
+			// Omit specific metadata keys not always present upon the original diff action
+			const { _sep, fsPath, ...json } = uri.toJSON();
+			return json;
+		};
 		return JSON.stringify({
-			original: tab.input.original.toJSON(),
-			modified: tab.input.modified.toJSON(),
+			original: serializeUri(tab.input.original),
+			modified: serializeUri(tab.input.modified),
 		});
 	}
 


### PR DESCRIPTION
Hello,

First, thank you for the efforts that went into providing and maintaining this VS Code extension.

While recently using the extension, I found myself in a situation where tabs corresponding to file diffs appear to get orphaned and prevent the tree view from closing the corresponding tree item.

![7](https://github.com/user-attachments/assets/cf3b5b0c-ed48-40d9-9cb8-857a8e2afda1)

To reproduce this, use the "Open Changes with Previous Revision" action (GitLens) on one file, then on another file, then try closing their tree items.

I did some code spelunking and eventually landed at the following portion.

https://github.com/billgoo/vscode-tab-group/blob/9c212b4e799677c175d0e308eb3486c43af403e6/src/TreeDataProvider.ts#L194-L198

I inspected the `getNormalizedId` result for `TabInputTextDiff` tabs and noticed that when performing a file diff for the first time, the `original` payload doesn't include certain metadata keys (`_sep` and `fsPath`) when the `Uri` instance gets serialised to JSON. However, if that diff tab is returned to (i.e. don't close the diff yet), the active tab would then include extra metadata keys, thus the tab lookup fails, and unexpected behaviour ensues.

A sample of what this payload looked like to me:

```json
{
  "original": {
    "$mid": 1,
    "external": "...",
    "path": "...",
    "scheme": "...",
    "authority": "...",
    "query": "..."
  },
  "modified": {
    "$mid": 1,
    "fsPath": "...",
    "_sep": 1,
    "external": "...",
    "path": "...",
    "scheme": "file"
  }
}
```

So my (naive) patch simply omits the metadata keys that aren't always guaranteed to be present when a file diff is performed, hopefully ensuring tab lookups always resolve successfully.

I'm open to any feedback for further changes if need be.