### PR TITLE
Fix (ViewTree): add provider to update TreeItem when files is modified & unsaved

### DIFF
--- a/src/TabFileDecorationProvider.ts
+++ b/src/TabFileDecorationProvider.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+
+export class TabFileDecorationProvider implements vscode.FileDecorationProvider {
+    private readonly _onDidChangeFileDecorations = new vscode.EventEmitter<vscode.Uri[]>();
+    readonly onDidChangeFileDecorations = this._onDidChangeFileDecorations.event;
+
+    constructor() {
+        // Listen to document changes to update decorations
+        vscode.workspace.onDidChangeTextDocument((e) => {
+            if (e.document.isDirty) {
+                this._onDidChangeFileDecorations.fire([e.document.uri]);
+            } else {
+                // When saved, remove decoration
+                this._onDidChangeFileDecorations.fire([e.document.uri]);
+            }
+        });
+
+        // Also listen to tab changes to refresh decorations
+        vscode.window.tabGroups.onDidChangeTabs(() => {
+            // Refresh all decorations
+            this._onDidChangeFileDecorations.fire([]);
+        });
+    }
+
+    provideFileDecoration(uri: vscode.Uri): vscode.ProviderResult<vscode.FileDecoration> {
+        // Check if the document is dirty (modified but not saved)
+        const document = vscode.workspace.textDocuments.find(doc => doc.uri.toString() === uri.toString());
+        if (document && document.isDirty) {
+            return {
+                badge: '⦿', // A dot to indicate modified
+                tooltip: 'Unsaved',
+                color: new vscode.ThemeColor('charts.orange'),
+                propagate: false
+            };
+        }
+        return undefined;
+    }
+}
+
+// Export a global instance for manual access
+export const tabFileDecorationProvider = new TabFileDecorationProvider();
+
+// Helper function to apply decoration to a TreeItem
+export function setTabDecoration(treeItem: vscode.TreeItem, uri: vscode.Uri, iconType: string = 'file'): void {
+    const decoration = tabFileDecorationProvider.provideFileDecoration(uri) as vscode.FileDecoration | undefined;
+
+    if (decoration) {
+        if (decoration.badge && treeItem.label) {
+            treeItem.label = `${decoration.badge} ${treeItem.label}`;
+        }
+        if (decoration.tooltip) {
+            treeItem.tooltip = decoration.tooltip;
+        }
+        if (decoration.color) {
+            treeItem.iconPath = new vscode.ThemeIcon(iconType, decoration.color);
+        }
+    }
+}

--- a/src/TabTypeHandler.ts
+++ b/src/TabTypeHandler.ts
@@ -1,6 +1,7 @@
 import path = require('node:path');
 import * as vscode from 'vscode';
 import { findLongestCommonFilePathPrefixIndex } from './TreeDataProvider';
+import { setTabDecoration } from './TabFileDecorationProvider';
 
 export type InputType = vscode.Tab["input"];
 
@@ -106,7 +107,12 @@ export class TabInputTextHandler implements TabTypeHandler<vscode.TabInputText> 
 	}
 
 	createTreeItem(tab: TypedTab<vscode.TabInputText>): vscode.TreeItem {
-		return new vscode.TreeItem(tab.input.uri);
+		const treeItem = new vscode.TreeItem(tab.input.uri);
+
+		treeItem.label = tab.label;
+		setTabDecoration(treeItem, tab.input.uri, 'file')
+
+		return treeItem
 	}
 
 	async openEditor(tab: TypedTab<vscode.TabInputText>): Promise<void> {
@@ -153,6 +159,9 @@ export class TabInputTextDiffHandler implements TabTypeHandler<vscode.TabInputTe
 			treeItem.description = path.join(...originalFilePathArray.slice(commonAncestorDirIndex + 1, -1))
 				+ " - " + path.join(...modifiedFilePathArray.slice(commonAncestorDirIndex + 1, -1));
 		}
+
+		setTabDecoration(treeItem, tab.input.modified, 'diff')
+
 		return treeItem;
 	}
 

--- a/src/TreeView.ts
+++ b/src/TreeView.ts
@@ -8,6 +8,7 @@ import { Group, isGroup, Tab, TreeItemType } from './types';
 import { getNativeTabs, TreeDataProvider } from './TreeDataProvider';
 import { Disposable } from './lifecycle';
 import { ContextKeys, setContext } from './context';
+import { tabFileDecorationProvider } from './TabFileDecorationProvider';
 
 export class TabsView extends Disposable {
 	private treeDataProvider: TreeDataProvider = this._register(new TreeDataProvider());
@@ -27,6 +28,11 @@ export class TabsView extends Disposable {
 		}));
 
 		this._register(this.treeDataProvider.onDidChangeTreeData(() => this.saveState(this.treeDataProvider.getState())));
+
+		// Listen to decoration changes to refresh the tree view
+		this._register(tabFileDecorationProvider.onDidChangeFileDecorations(() => {
+			this.treeDataProvider.triggerRerender();
+		}));
 
 		this._register(vscode.commands.registerCommand('tabsTreeView.tab.close', (tab: Tab) => vscode.window.tabGroups.close(getNativeTabs(tab))));
 


### PR DESCRIPTION
To resolve the issue: https://github.com/billgoo/vscode-tab-group/issues/34

## Changes

Add a _FileDecoratorProvider_ to manipulate the properties of an ItemTree

In this way we can update the tabs to show unsaved state

| Before | Now |
| ------- | ----- |
| <img width="706" height="274" alt="imagen" src="https://github.com/user-attachments/assets/e0e847c2-33d3-4aed-bd85-f966012ff071" /> | <img width="675" height="245" alt="imagen" src="https://github.com/user-attachments/assets/ccfce560-2285-4357-9a14-01cc088efce3" /> |

I hope this _FileDecoratorProvider_ could allow us to have more control about the behavior of the tabs
