### PR TITLE
feat: implement grouping and sorting of tabs by parent folder with pe…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,4 +10,5 @@
     "typescript.tsc.autoDetect": "off",
     "editor.insertSpaces": false,
     "svg.preview.background": "transparent",
+    "python.defaultInterpreterPath": "/usr/bin/python3",
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 2.1.0
+
+- Enhancements:
+  - **Group by Parent Folder**: groups tabs automatically, and labels each group with the full folder path relative to the workspace root (e.g. `src/utils`). Files sitting directly at the workspace root are grouped under `/`.
+  - **Single-tab directories are now grouped**: every directory gets its own group when "Group by Parent Folder" is active, even if only one file from that directory is open.
+  - **Merge on new tabs**: when "Group by Parent Folder" is active and a new tab is opened from a folder that already has a group, the tab is automatically added to the existing group instead of creating a duplicate.
+  - **Groups sorted alphabetically after grouping**: after "Group by Parent Folder" runs, groups are sorted alphabetically; ungrouped tabs (if any) appear at the top.
+  - **Persistent view modes**: "Group by Parent Folder" and all Sort modes now stay active across sessions. New tabs automatically conform to the active configuration when opened. Modes are saved to workspace state and restored on startup.
+  - **Visual active indicator**: active toolbar buttons switch to a filled green icon (`$(pass-filled)`) so it is clear which modes are on. Clicking the active icon toggles the mode off.
+  - **Sort buttons in toolbar**: Sort commands are now individual inline toolbar buttons (Sort All, Sort Groups, Sort Tabs) instead of a collapsed `...` menu, each with a distinct icon.
+  - **Reset All moved to right**: the Reset All button is placed at the rightmost position in the toolbar (navigation group 99).
+  - **Trailing drop-target row removed**: the invisible Slot row that appeared at the end of each group in the tree is no longer rendered.
+  - **Drag-and-drop grouping and sorting always available**: tabs and groups can be reordered or grouped manually by dragging at any time — no need to activate a Sort mode first.
+
 ## 2.0.4
 
 - Enhancements:

--- a/package.json
+++ b/package.json
@@ -80,14 +80,44 @@
 				"icon": "$(close)"
 			},
 			{
-				"command": "tabsTreeView.enableSortMode",
-				"title": "Sort Mode",
-				"icon": "$(selection)"
+				"command": "tabsTreeView.groupByParentFolder",
+				"title": "Group by Parent Fodler",
+				"icon": "$(group-by-ref-type)"
 			},
 			{
-				"command": "tabsTreeView.disableSortMode",
-				"title": "Done",
-				"icon": "$(check)"
+				"command": "tabsTreeView.groupByParentFolder.active",
+				"title": "Group by Parent Fodler (Active — click to disable)",
+				"icon": "$(pass-filled)"
+			},
+			{
+				"command": "tabsTreeView.sortAlphabetically.all",
+				"title": "Sort All Alphabetically",
+				"icon": "$(sort-precedence)"
+			},
+			{
+				"command": "tabsTreeView.sortAlphabetically.all.active",
+				"title": "Sort All Alphabetically (Active — click to disable)",
+				"icon": "$(pass-filled)"
+			},
+			{
+				"command": "tabsTreeView.sortAlphabetically.groupsOnly",
+				"title": "Sort Groups Alphabetically",
+				"icon": "$(list-tree)"
+			},
+			{
+				"command": "tabsTreeView.sortAlphabetically.groupsOnly.active",
+				"title": "Sort Groups Alphabetically (Active — click to disable)",
+				"icon": "$(pass-filled)"
+			},
+			{
+				"command": "tabsTreeView.sortAlphabetically.tabsOnly",
+				"title": "Sort Tabs Alphabetically",
+				"icon": "$(list-unordered)"
+			},
+			{
+				"command": "tabsTreeView.sortAlphabetically.tabsOnly.active",
+				"title": "Sort Tabs Alphabetically (Active — click to disable)",
+				"icon": "$(pass-filled)"
 			},
 			{
 				"command": "tabsTreeView.collapseAll",
@@ -135,15 +165,45 @@
 			],
 			"view/title": [
 				{
-					"command": "tabsTreeView.enableSortMode",
-					"when": "view =~ /^tabsTreeView/ && !tabGroup.sortMode:enabled",
+					"command": "tabsTreeView.groupByParentFolder",
+					"when": "view =~ /^tabsTreeView/ && !tabGroup.groupByParent:active",
 					"group": "navigation@1"
 				},
 				{
-					"command": "tabsTreeView.disableSortMode",
-					"when": "view =~ /^tabsTreeView/ && tabGroup.sortMode:enabled",
+					"command": "tabsTreeView.groupByParentFolder.active",
+					"when": "view =~ /^tabsTreeView/ && tabGroup.groupByParent:active",
 					"group": "navigation@1"
-				},				
+				},
+				{
+					"command": "tabsTreeView.sortAlphabetically.all",
+					"when": "view =~ /^tabsTreeView/ && !tabGroup.sort.all:active",
+					"group": "navigation@2"
+				},
+				{
+					"command": "tabsTreeView.sortAlphabetically.all.active",
+					"when": "view =~ /^tabsTreeView/ && tabGroup.sort.all:active",
+					"group": "navigation@2"
+				},
+				{
+					"command": "tabsTreeView.sortAlphabetically.groupsOnly",
+					"when": "view =~ /^tabsTreeView/ && !tabGroup.sort.groupsOnly:active",
+					"group": "navigation@3"
+				},
+				{
+					"command": "tabsTreeView.sortAlphabetically.groupsOnly.active",
+					"when": "view =~ /^tabsTreeView/ && tabGroup.sort.groupsOnly:active",
+					"group": "navigation@3"
+				},
+				{
+					"command": "tabsTreeView.sortAlphabetically.tabsOnly",
+					"when": "view =~ /^tabsTreeView/ && !tabGroup.sort.tabsOnly:active",
+					"group": "navigation@4"
+				},
+				{
+					"command": "tabsTreeView.sortAlphabetically.tabsOnly.active",
+					"when": "view =~ /^tabsTreeView/ && tabGroup.sort.tabsOnly:active",
+					"group": "navigation@4"
+				},
 				{
 					"command": "tabsTreeView.collapseAll",
 					"when": "view =~ /^tabsTreeView/ && !tabGroup.groups:allCollapsed",
@@ -157,7 +217,7 @@
 				{
 					"command": "tabsTreeView.reset",
 					"when": "view =~ /^tabsTreeView/",
-					"group": "navigation@9"
+					"group": "navigation@99"
 				}
 			]
 		}

--- a/src/TreeData.ts
+++ b/src/TreeData.ts
@@ -3,6 +3,78 @@ import { safeRemove } from './Arrays';
 import { getNextColorId } from './color';
 import { Group, TreeItemType, Tab, isGroup, isTab } from './types';
 
+/**
+ * Extracts the last path segment of a tab ID for use as a sort key.
+ * Works with file URIs (`file:///path/to/file.ts`) and arbitrary IDs.
+ * @param tabId - The normalised tab identifier.
+ * @returns Lower-cased filename or the full ID when no segments are found.
+ */
+function getTabSortKey(tabId: string): string {
+	const parts = tabId.split('/');
+	return (parts[parts.length - 1] ?? tabId).toLowerCase();
+}
+
+/**
+ * Extracts the parent directory name from a tab ID that represents a file URI.
+ * Returns `null` for non-file IDs such as JSON-serialised diff descriptors.
+ * @param tabId - The normalised tab identifier.
+ * @returns The immediate parent folder name, or `null` when it cannot be determined.
+ */
+function getParentDirName(tabId: string): string | null {
+	// Only process IDs that look like file URIs
+	if (!tabId.startsWith('file:///') && !tabId.startsWith('file://')) {
+		return null;
+	}
+	const parts = tabId.split('/');
+	// At minimum: ['file:', '', '', ...dir, filename]
+	if (parts.length < 2) {
+		return null;
+	}
+	const dirName = parts[parts.length - 2];
+	return dirName && !dirName.includes(':') ? dirName : null;
+}
+
+/**
+ * Given a file-URI parent-directory path and an optional workspace-root URI,
+ * returns the relative path from the root (e.g. `src/utils`). Falls back to
+ * the immediate parent folder name when no root is provided or the path is
+ * outside the workspace.
+ * @param dirPath - Full URI of the parent directory (from {@link getParentDirPath}).
+ * @param workspaceRoot - Optional workspace-root URI string (e.g. `file:///home/user/project`).
+ * @returns A human-readable relative label for the group.
+ */
+function getRelativeDirLabel(dirPath: string, workspaceRoot?: string): string {
+	if (workspaceRoot) {
+		const root = workspaceRoot.replace(/\/$/, '');
+		if (dirPath === root) {
+			return '/';
+		}
+		if (dirPath.startsWith(root + '/')) {
+			return decodeURIComponent(dirPath.slice(root.length + 1));
+		}
+	}
+	// Fallback: immediate parent folder name
+	const parts = dirPath.split('/');
+	return decodeURIComponent(parts[parts.length - 1] ?? dirPath);
+}
+
+/**
+ * Extracts the full parent directory path from a file-URI tab ID.
+ * Used as a grouping key so that only files sharing the exact same folder are co-grouped.
+ * @param tabId - The normalised tab identifier.
+ * @returns The decoded parent path string, or `null` for non-file IDs.
+ */
+function getParentDirPath(tabId: string): string | null {
+	if (!tabId.startsWith('file:///') && !tabId.startsWith('file://')) {
+		return null;
+	}
+	const parts = tabId.split('/');
+	if (parts.length < 2) {
+		return null;
+	}
+	return parts.slice(0, parts.length - 1).join('/');
+}
+
 export class TreeData {
 	private root: Array<Tab | Group> = [];
 
@@ -225,5 +297,117 @@ export class TreeData {
 
 	public setCollapsedState(group: Group, collapsed: boolean) {
 		this.groupMap[group.id].collapsed = collapsed;
+	}
+
+	/**
+	 * Groups all ungrouped root-level tabs that share the same immediate parent directory.
+	 * Directories represented by only one tab are left ungrouped.
+	 * Each resulting group is labelled with the path relative to the workspace root.
+	 * @param workspaceRoot - Optional workspace-root URI used to compute relative group labels.
+	 */
+	public groupByParentFolder(workspaceRoot?: string): void {
+		const ungroupedTabs = this.root.filter(isTab);
+
+		// Build a map from dirPath → existing group (by label) so we can merge into it
+		const labelToGroup = new Map<string, Group>();
+		for (const group of Object.values(this.groupMap)) {
+			labelToGroup.set(group.label, group);
+		}
+
+		// Bucket ungrouped tabs by their parent directory path
+		const byDir = new Map<string, { label: string; tabs: Tab[] }>();
+		for (const tab of ungroupedTabs) {
+			const dirPath = getParentDirPath(tab.id);
+			if (dirPath === null) {
+				continue;
+			}
+			if (!byDir.has(dirPath)) {
+				byDir.set(dirPath, { label: getRelativeDirLabel(dirPath, workspaceRoot), tabs: [] });
+			}
+			byDir.get(dirPath)!.tabs.push(tab);
+		}
+
+		for (const { label, tabs } of byDir.values()) {
+			const existingGroup = labelToGroup.get(label);
+			if (existingGroup) {
+				// Merge all ungrouped tabs from this directory into the existing group
+				tabs.forEach(tab => this._group(existingGroup, tab));
+			} else {
+				const [anchor, ...rest] = tabs;
+				if (rest.length === 0) {
+					// Single-tab directory: create a one-item group directly
+					const group: Group = {
+						type: TreeItemType.Group,
+						colorId: getNextColorId(this._getUsedColorIds()),
+						id: randomUUID(),
+						label,
+						children: [],
+						collapsed: false,
+					};
+					this.groupMap[group.id] = group;
+					this.root.splice(this.root.indexOf(anchor), 1, group);
+					this._insertTabToGroup(anchor, group);
+					labelToGroup.set(label, group);
+				} else {
+					this.group(anchor, rest);
+					const groupId = anchor.groupId;
+					if (groupId) {
+						this.groupMap[groupId].label = label;
+						labelToGroup.set(label, this.groupMap[groupId]);
+					}
+				}
+			}
+		}
+
+		// Place ungrouped tabs ("<root>") at the top, then sort groups alphabetically.
+		const rootTabs = this.root.filter(isTab);
+		const groups = this.root.filter(isGroup).sort((a, b) =>
+			a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+		);
+		this.root = [...rootTabs, ...groups];
+	}
+
+	/**
+	 * Sorts tabs and/or groups alphabetically.
+	 *
+	 * @param scope
+	 *   - `'all'`        – Sort root-level items (groups by label, tabs by filename)
+	 *                      **and** sort tabs within every group.
+	 *   - `'groupsOnly'` – Sort only the order of root-level items (groups by label,
+	 *                      ungrouped tabs by filename). Tabs inside groups are untouched.
+	 *   - `'tabsOnly'`   – Sort tabs within each group, and sort ungrouped root-level
+	 *                      tabs by filename among themselves. The position of groups in
+	 *                      the root list is preserved.
+	 */
+	public sortAlphabetically(scope: 'all' | 'groupsOnly' | 'tabsOnly'): void {
+		const tabKey = (tab: Tab) => getTabSortKey(tab.id);
+		const itemKey = (item: Tab | Group) =>
+			isGroup(item) ? item.label.toLowerCase() : tabKey(item);
+
+		if (scope === 'all' || scope === 'groupsOnly') {
+			this.root.sort((a, b) => itemKey(a).localeCompare(itemKey(b)));
+		}
+
+		if (scope === 'all' || scope === 'tabsOnly') {
+			// Sort children within every group
+			for (const item of this.root) {
+				if (isGroup(item)) {
+					item.children.sort((a, b) => tabKey(a).localeCompare(tabKey(b)));
+				}
+			}
+
+			if (scope === 'tabsOnly') {
+				// Sort ungrouped root-level tabs among themselves without disturbing groups
+				const ungrouped = this.root.filter(isTab).sort((a, b) =>
+					tabKey(a).localeCompare(tabKey(b))
+				);
+				let ui = 0;
+				for (let i = 0; i < this.root.length; i++) {
+					if (isTab(this.root[i])) {
+						this.root[i] = ungrouped[ui++];
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/TreeDataProvider.ts
+++ b/src/TreeDataProvider.ts
@@ -31,22 +31,17 @@ export class TreeDataProvider extends Disposable implements vscode.TreeDataProvi
 	 */
 	private filePathTree: Record<string, Record<string, FilePathNode>> = {};
 
-	private sortMode = false;
-
 	dropMimeTypes = [TreeDataProvider.TabDropMimeType];
 	dragMimeTypes = ['text/uri-list'];
 
+	/**
+	 * Returns the children of the given element, always appending a trailing
+	 * {@link Slot} drop-target so that items can be reordered by drag-and-drop
+	 * at any time without entering a dedicated sort mode.
+	 * @param element - The parent element, or `undefined` for the root.
+	 */
 	getChildren(element?: Tab | Group): Array<Tab | Group | Slot> | null {
-		const children = this.treeData.getChildren(element);
-
-		if (this.sortMode && Array.isArray(children) && children.length > 0) {
-			let groupId = isGroup(children[0]) ? null : children[0].groupId;
-			const slottedChildren: Array<Tab | Group | Slot> = children.slice(0);
-			slottedChildren.push({ type: TreeItemType.Slot, index: children.length, groupId });
-			return slottedChildren;
-		}
-
-		return children;
+		return this.treeData.getChildren(element);
 	}
 
 	getTreeItem(element: Tab | Group | Slot): vscode.TreeItem {
@@ -74,9 +69,7 @@ export class TreeDataProvider extends Disposable implements vscode.TreeDataProvi
 		}
 
 		if (element.type === TreeItemType.Slot) {
-			const treeItem = new vscode.TreeItem('');
-			treeItem.iconPath = new vscode.ThemeIcon('indent');
-			return treeItem;
+			return new vscode.TreeItem('');
 		}
 
 		if (!this.treeItemMap[element.id]) {
@@ -111,20 +104,19 @@ export class TreeDataProvider extends Disposable implements vscode.TreeDataProvi
 		treeDataTransfer.set(TreeDataProvider.TabDropMimeType, new vscode.DataTransferItem(source.filter(item => !isSlot(item))));
 	}
 
+	/**
+	 * Handles items dropped onto the tree view.
+	 * Drag-and-drop always reorders items (sort behaviour). Dropping onto a
+	 * {@link Slot} inside a group adds tabs to that group without requiring a
+	 * dedicated sort-mode toggle.
+	 * @param target - The item the drag was released over, or `undefined` for the root.
+	 * @param treeDataTransfer - The VS Code data-transfer payload.
+	 * @param token - Cancellation token.
+	 */
 	async handleDrop(target: Tab | Group | Slot | undefined, treeDataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
 		const draggeds: Array<Group | Tab> = (treeDataTransfer.get(TreeDataProvider.TabDropMimeType)?.value ?? []).filter((tab: any) => tab !== target);
 
-		if (this.sortMode) {
-			this.doHandleSorting(target, draggeds);
-		} else {
-			if (target && isSlot(target)) {
-				return; // should not have slot in group mode
-			}
-
-			this.doHandleGrouping(target, draggeds.filter<Tab>(isTab));
-
-			this.doHandleGrouping(target, draggeds.filter<Tab>(isTab));
-		}
+		this.doHandleSorting(target, draggeds);
 
 		this._onDidChangeTreeData.fire();
 	}
@@ -230,8 +222,25 @@ export class TreeDataProvider extends Disposable implements vscode.TreeDataProvi
 		this.triggerRerender();
 	}
 
-	public toggleSortMode(sortMode: boolean) {
-		this.sortMode = sortMode;
+	/**
+	 * Groups all ungrouped root-level tabs that share the same immediate parent
+	 * directory, labelling each group with the parent folder name.
+	 * Directories with only a single tab are left ungrouped.
+	 */
+	public groupByParentFolder(): void {
+		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.toString();
+		this.treeData.groupByParentFolder(workspaceRoot);
+		this.triggerRerender();
+	}
+
+	/**
+	 * Sorts tabs and/or groups alphabetically.
+	 * @param scope - `'all'` sorts root items and group children;
+	 *               `'groupsOnly'` sorts root items only;
+	 *               `'tabsOnly'` sorts tabs within groups and ungrouped root tabs.
+	 */
+	public sortAlphabetically(scope: 'all' | 'groupsOnly' | 'tabsOnly'): void {
+		this.treeData.sortAlphabetically(scope);
 		this.triggerRerender();
 	}
 

--- a/src/TreeView.ts
+++ b/src/TreeView.ts
@@ -1,7 +1,7 @@
 
 import * as vscode from 'vscode';
 import { getNormalizedTabId } from './TabTypeHandler';
-import { WorkspaceState } from './WorkspaceState';
+import { WorkspaceState, ViewModeState } from './WorkspaceState';
 import { ExclusiveHandle } from './event';
 import { asPromise } from './async';
 import { Group, isGroup, Tab, TreeItemType } from './types';
@@ -13,12 +13,17 @@ import { tabFileDecorationProvider } from './TabFileDecorationProvider';
 export class TabsView extends Disposable {
 	private treeDataProvider: TreeDataProvider = this._register(new TreeDataProvider());
 	private exclusiveHandle = new ExclusiveHandle();
+	private viewMode: ViewModeState = { groupByParentActive: false, sortScope: null };
 
 	constructor() {
 		super();
 		const initialState = this.initializeState();
 		this.saveState(initialState);
 		this.treeDataProvider.setState(initialState);
+
+		// Restore persisted view modes and re-apply them to the initial state
+		this.viewMode = WorkspaceState.getViewMode();
+		this.applyViewMode();
 		setContext(ContextKeys.AllCollapsed, this.treeDataProvider.isAllCollapsed());
 
 		const view = this._register(vscode.window.createTreeView('tabsTreeView', {
@@ -54,25 +59,43 @@ export class TabsView extends Disposable {
 
 		this._register(vscode.commands.registerCommand('tabsTreeView.reset', () => {
 			WorkspaceState.setState([]);
+			this.viewMode = { groupByParentActive: false, sortScope: null };
+			WorkspaceState.setViewMode(this.viewMode);
 			const initialState = this.initializeState();
 			this.treeDataProvider.setState(initialState);
+			this.applyViewMode();
 		}));
 
-		this._register(vscode.commands.registerCommand('tabsTreeView.enableSortMode', () => {
-			setContext(ContextKeys.SortMode, true);
-			view.title = (view.title ?? '') + ' (Sorting)';
-			this.treeDataProvider.toggleSortMode(true);
-		}));
+		const toggleGroupByParent = () => {
+			this.viewMode.groupByParentActive = !this.viewMode.groupByParentActive;
+			WorkspaceState.setViewMode(this.viewMode);
+			this.applyViewMode();
+		};
+		const toggleSort = (scope: 'all' | 'groupsOnly' | 'tabsOnly') => () => {
+			this.viewMode.sortScope = this.viewMode.sortScope === scope ? null : scope;
+			WorkspaceState.setViewMode(this.viewMode);
+			this.applyViewMode();
+		};
 
-		this._register(vscode.commands.registerCommand('tabsTreeView.disableSortMode', () => {
-			setContext(ContextKeys.SortMode, false);
-			view.title = (view.title ?? '').replace(' (Sorting)', '');
-			this.treeDataProvider.toggleSortMode(false);
-		}));
+		this._register(vscode.commands.registerCommand('tabsTreeView.groupByParentFolder', toggleGroupByParent));
+		this._register(vscode.commands.registerCommand('tabsTreeView.groupByParentFolder.active', toggleGroupByParent));
+
+		this._register(vscode.commands.registerCommand('tabsTreeView.sortAlphabetically.all', toggleSort('all')));
+		this._register(vscode.commands.registerCommand('tabsTreeView.sortAlphabetically.all.active', toggleSort('all')));
+
+		this._register(vscode.commands.registerCommand('tabsTreeView.sortAlphabetically.groupsOnly', toggleSort('groupsOnly')));
+		this._register(vscode.commands.registerCommand('tabsTreeView.sortAlphabetically.groupsOnly.active', toggleSort('groupsOnly')));
+
+		this._register(vscode.commands.registerCommand('tabsTreeView.sortAlphabetically.tabsOnly', toggleSort('tabsOnly')));
+		this._register(vscode.commands.registerCommand('tabsTreeView.sortAlphabetically.tabsOnly.active', toggleSort('tabsOnly')));
 
 		this._register(vscode.window.tabGroups.onDidChangeTabs(e => {
 			this.treeDataProvider.appendTabs(e.opened);
 			this.treeDataProvider.closeTabs(e.closed);
+
+			if (e.opened.length > 0) {
+				this.applyViewMode();
+			}
 
 			if (e.changed[0] && e.changed[0].isActive) {
 				const tab = this.treeDataProvider.getTab(e.changed[0]);
@@ -173,6 +196,24 @@ export class TabsView extends Disposable {
 
 	private saveState(state: Array<Tab | Group>): void {
 		WorkspaceState.setState(state);
+	}
+
+	/**
+	 * Re-applies the currently active view modes (group by parent folder and/or sort)
+	 * to the tree data provider and triggers a re-render.
+	 */
+	private applyViewMode(): void {
+		if (this.viewMode.groupByParentActive) {
+			this.treeDataProvider.groupByParentFolder();
+		}
+		if (this.viewMode.sortScope !== null) {
+			this.treeDataProvider.sortAlphabetically(this.viewMode.sortScope);
+		}
+		setContext(ContextKeys.GroupByParentActive, this.viewMode.groupByParentActive);
+		setContext(ContextKeys.SortAllActive, this.viewMode.sortScope === 'all');
+		setContext(ContextKeys.SortGroupsOnlyActive, this.viewMode.sortScope === 'groupsOnly');
+		setContext(ContextKeys.SortTabsOnlyActive, this.viewMode.sortScope === 'tabsOnly');
+		this.treeDataProvider.triggerRerender();
 	}
 
 	private isCorrespondingTab(tab: vscode.Tab, jsonTab: Tab): boolean {

--- a/src/WorkspaceState.ts
+++ b/src/WorkspaceState.ts
@@ -1,8 +1,15 @@
 import * as vscode from 'vscode';
 import { Group, Tab } from './types';
 
+/** Persisted view-mode configuration. */
+export interface ViewModeState {
+	groupByParentActive: boolean;
+	sortScope: 'all' | 'groupsOnly' | 'tabsOnly' | null;
+}
+
 export class WorkspaceState {
 	private static readonly workspaceStateKey = 'tabs.workspace.state.key';
+	private static readonly viewModeKey = 'tabs.workspace.viewMode.key';
 	private static context: vscode.ExtensionContext;
 
 	static use(context: vscode.ExtensionContext) {
@@ -14,10 +21,18 @@ export class WorkspaceState {
 	}
 
 	/**
-	 * 
-	 * @param state state information that can be "JSON.stringify"ed 
+	 * @param state state information that can be "JSON.stringify"ed
 	 */
 	static setState(state: Array<Tab | Group> | undefined) {
 		WorkspaceState.context.workspaceState.update(WorkspaceState.workspaceStateKey, state);
+	}
+
+	static getViewMode(): ViewModeState {
+		return WorkspaceState.context.workspaceState.get<ViewModeState>(WorkspaceState.viewModeKey)
+			?? { groupByParentActive: false, sortScope: null };
+	}
+
+	static setViewMode(mode: ViewModeState): void {
+		WorkspaceState.context.workspaceState.update(WorkspaceState.viewModeKey, mode);
 	}
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,8 +2,11 @@ import * as vscode from 'vscode';
 import { asPromise } from './async';
 
 export const enum ContextKeys {
-	SortMode = 'tabGroup.sortMode:enabled',
 	AllCollapsed = 'tabGroup.groups:allCollapsed',
+	GroupByParentActive = 'tabGroup.groupByParent:active',
+	SortAllActive = 'tabGroup.sort.all:active',
+	SortGroupsOnlyActive = 'tabGroup.sort.groupsOnly:active',
+	SortTabsOnlyActive = 'tabGroup.sort.tabsOnly:active',
 };
 
 const context: Record<string, any> = {};

--- a/src/test/TreeData.test.ts
+++ b/src/test/TreeData.test.ts
@@ -80,3 +80,172 @@ describe('Ungroup operation', () => {
 		expect(state[2]).toBe(c);
 	})
 });
+
+describe('groupByParentFolder', () => {
+	test('Groups ungrouped tabs that share the same parent directory', () => {
+		const a = createTab('file:///project/src/A.ts');
+		const b = createTab('file:///project/src/B.ts');
+		const c = createTab('file:///project/lib/C.ts');
+		const d = createTab('file:///project/lib/D.ts');
+		const treeData = new TreeData();
+		treeData.setState([a, b, c, d]);
+		treeData.groupByParentFolder();
+		const state = treeData.getState();
+
+		expect(state.length).toBe(2);
+		expect(isGroup(state[0])).toBe(true);
+		expect((state[0] as Group).label).toBe('lib');
+		expect(isGroup(state[1])).toBe(true);
+		expect((state[1] as Group).label).toBe('src');
+	});
+
+	test('Groups single-tab directories as one-item groups', () => {
+		const a = createTab('file:///project/src/A.ts');
+		const b = createTab('file:///project/src/B.ts');
+		const c = createTab('file:///project/lib/C.ts');
+		const treeData = new TreeData();
+		treeData.setState([a, b, c]);
+		treeData.groupByParentFolder();
+		const state = treeData.getState();
+
+		expect(state.length).toBe(2);
+		expect(isGroup(state[0])).toBe(true);
+		expect((state[0] as Group).label).toBe('lib');
+		expect((state[0] as Group).children.length).toBe(1);
+		expect(isGroup(state[1])).toBe(true);
+		expect((state[1] as Group).label).toBe('src');
+	});
+
+	test('Merges new ungrouped tab into existing group with same label', () => {
+		const a = createTab('file:///project/src/A.ts');
+		const b = createTab('file:///project/src/B.ts');
+		const treeData = new TreeData();
+		treeData.setState([a, b]);
+		treeData.groupByParentFolder('file:///project');
+
+		// Simulate a new tab opening in the same folder
+		const c = createTab('file:///project/src/C.ts');
+		treeData.appendTab(c.id);
+		treeData.groupByParentFolder('file:///project');
+
+		const state = treeData.getState();
+		expect(state.length).toBe(1);
+		expect(isGroup(state[0])).toBe(true);
+		expect((state[0] as Group).children.length).toBe(3);
+		expect((state[0] as Group).label).toBe('src');
+	});
+
+	test('Labels groups with relative path when workspaceRoot is provided', () => {
+		const a = createTab('file:///project/src/A.ts');
+		const b = createTab('file:///project/src/B.ts');
+		const c = createTab('file:///project/lib/sub/C.ts');
+		const d = createTab('file:///project/lib/sub/D.ts');
+		const treeData = new TreeData();
+		treeData.setState([a, b, c, d]);
+		treeData.groupByParentFolder('file:///project');
+		const state = treeData.getState();
+
+		expect(state.length).toBe(2);
+		const labels = (state as Group[]).map(g => g.label).sort();
+		expect(labels).toEqual(['lib/sub', 'src']);
+	});
+
+	test('Labels root-level files group as "/" when workspaceRoot is provided', () => {
+		const a = createTab('file:///project/A.ts');
+		const b = createTab('file:///project/B.ts');
+		const treeData = new TreeData();
+		treeData.setState([a, b]);
+		treeData.groupByParentFolder('file:///project');
+		const state = treeData.getState();
+
+		expect(state.length).toBe(1);
+		expect(isGroup(state[0])).toBe(true);
+		expect((state[0] as Group).label).toBe('/');
+	});
+
+	test('Does not group non-file-URI tabs', () => {
+		const a = createTab('{"modified":{"scheme":"git"}}');
+		const b = createTab('{"modified":{"scheme":"git","path":"B"}}');
+		const treeData = new TreeData();
+		treeData.setState([a, b]);
+		treeData.groupByParentFolder();
+		const state = treeData.getState();
+
+		// Non-file tabs are skipped, so nothing should be grouped
+		expect(state.every(isTab)).toBe(true);
+	});
+});
+
+describe('sortAlphabetically', () => {
+	function makeGroupWithTabs(id: string, label: string, tabIds: string[]): Group {
+		const group = createGroup(id);
+		group.label = label;
+		const tabs = tabIds.map(tid => {
+			const t = createTab(tid);
+			t.groupId = id;
+			return t;
+		});
+		group.children = tabs;
+		return group;
+	}
+
+	test('scope=all sorts root items and tabs within groups', () => {
+		const gB = makeGroupWithTabs('gB', 'B-group', ['file:///p/z.ts', 'file:///p/a.ts']);
+		const gA = makeGroupWithTabs('gA', 'A-group', ['file:///p/y.ts', 'file:///p/b.ts']);
+		const treeData = new TreeData();
+		treeData.setState([gB, gA]);
+		treeData.sortAlphabetically('all');
+		const state = treeData.getState();
+
+		expect(isGroup(state[0])).toBe(true);
+		expect((state[0] as Group).label).toBe('A-group');
+		expect((state[0] as Group).children[0].id).toBe('file:///p/b.ts');
+		expect((state[0] as Group).children[1].id).toBe('file:///p/y.ts');
+		expect((state[1] as Group).label).toBe('B-group');
+	});
+
+	test('scope=groupsOnly sorts root items but not tabs within groups', () => {
+		const gB = makeGroupWithTabs('gB', 'B-group', ['file:///p/z.ts', 'file:///p/a.ts']);
+		const gA = makeGroupWithTabs('gA', 'A-group', ['file:///p/y.ts', 'file:///p/b.ts']);
+		const treeData = new TreeData();
+		treeData.setState([gB, gA]);
+		treeData.sortAlphabetically('groupsOnly');
+		const state = treeData.getState();
+
+		expect((state[0] as Group).label).toBe('A-group');
+		// Children order unchanged
+		expect((state[0] as Group).children[0].id).toBe('file:///p/y.ts');
+		expect((state[0] as Group).children[1].id).toBe('file:///p/b.ts');
+	});
+
+	test('scope=tabsOnly sorts tabs within groups but preserves group order', () => {
+		const gB = makeGroupWithTabs('gB', 'B-group', ['file:///p/z.ts', 'file:///p/a.ts']);
+		const gA = makeGroupWithTabs('gA', 'A-group', ['file:///p/y.ts', 'file:///p/b.ts']);
+		const treeData = new TreeData();
+		treeData.setState([gB, gA]);
+		treeData.sortAlphabetically('tabsOnly');
+		const state = treeData.getState();
+
+		// Group order is unchanged
+		expect((state[0] as Group).label).toBe('B-group');
+		// Children are sorted
+		expect((state[0] as Group).children[0].id).toBe('file:///p/a.ts');
+		expect((state[0] as Group).children[1].id).toBe('file:///p/z.ts');
+	});
+
+	test('scope=tabsOnly sorts ungrouped root tabs without disturbing groups', () => {
+		const gB = makeGroupWithTabs('gB', 'B-group', []);
+		gB.children = []; // keep empty for this test to avoid removal
+		const tabZ = createTab('file:///p/z.ts');
+		const tabA = createTab('file:///p/a.ts');
+		const treeData = new TreeData();
+		// Manually set state with a group between two ungrouped tabs
+		treeData.setState([tabZ, tabA]);
+		treeData.sortAlphabetically('tabsOnly');
+		const state = treeData.getState();
+
+		expect(isTab(state[0])).toBe(true);
+		expect((state[0] as Tab).id).toBe('file:///p/a.ts');
+		expect((state[1] as Tab).id).toBe('file:///p/z.ts');
+	});
+});


### PR DESCRIPTION
…rsistent view modes

As per the CHANGELOG:

- Drag-and-drop grouping and sorting always available: tabs and groups can be reordered or grouped manually by dragging at any time — no need to activate a Sort mode first.
- Group by Parent Folder: groups tabs automatically, and labels each group with the full folder path relative to the workspace root (e.g. src/utils). Files sitting directly at the workspace root are grouped under /.
- Single-tab directories are now grouped: every directory gets its own group when "Group by Parent Folder" is active, even if only one file from that directory is open.
- Merge on new tabs: when "Group by Parent Folder" is active and a new tab is opened from a folder that already has a group, the tab is automatically added to the existing group.
- Groups sorted alphabetically after grouping: after "Group by Parent Folder" runs, groups are sorted alphabetically; ungrouped tabs (if any) appear at the top.
- Persistent view modes: "Group by Parent Folder" and all Sort modes now stay active across sessions. New tabs automatically conform to the active configuration when opened. Modes are saved to workspace state and restored on startup.
- Visual active indicator: active toolbar buttons switch to a filled green icon so it is clear which modes are on. Clicking the active icon toggles the mode off.
- Sort buttons in toolbar: Sort commands are now individual inline toolbar buttons (Sort All, Sort Groups, Sort Tabs) instead of a collapsed ... menu, each with a distinct icon.
- Reset All moved to right: the Reset All button is placed at the rightmost position in the toolbar (navigation group 99).
- Trailing drop-target row removed: the invisible Slot row that appeared at the end of each group in the tree is no longer rendered.