### PR TITLE
feat(release): attach VSIX packages to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,29 @@ jobs:
           path: '*.vsix'
           if-no-files-found: error
 
+  attach-release-asset:
+    name: Attach VSIX to GitHub Release
+    if: ${{ github.event_name == 'push' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: tab-group-${{ env.RELEASE_TAG }}-vsix
+          path: release
+      - name: Create or update GitHub Release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          vsix_path="$(find release -maxdepth 1 -name '*.vsix' -print -quit)"
+          test -n "${vsix_path}"
+          if ! gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release create "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --verify-tag --title "${RELEASE_TAG}" --generate-notes || gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}"
+          fi
+          gh release upload "${RELEASE_TAG}" "${vsix_path}" --repo "${GITHUB_REPOSITORY}" --clobber
+
   publish:
     name: Publish tagged release
     if: ${{ github.event_name == 'push' || inputs.publish }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,7 +48,17 @@ Run `npm run package` to compile the extension and create an installable `.vsix`
    npm run publish:local -- --package-only
    ```
 
-5. Commit the release changes, merge them to `main`, then create an annotated tag matching the version and push it:
+5. Commit the release changes and merge them to `main`.
+
+6. Create the GitHub Release for the matching tag:
+
+   1. Open the repository **Releases** page and select **Draft a new release**.
+   2. Enter `<package-version>` as the tag, create the tag from `main`, and use the same value as the release title.
+   3. Add the release notes and select **Publish release**.
+
+   Publishing the GitHub Release creates the tag and starts `.github/workflows/release.yml`. After validation, the workflow attaches the generated `tab-group-<package-version>.vsix` to that GitHub Release and retains the same file as an Actions artifact.
+
+   A tag pushed from Git also starts the workflow; when no GitHub Release exists yet, the workflow creates one and attaches the VSIX:
 
    ```bash
    git checkout main
@@ -57,7 +67,7 @@ Run `npm run package` to compile the extension and create an installable `.vsix`
    git push origin <package-version>
    ```
 
-6. Pushing a semantic version tag, such as `2.0.5`, starts `.github/workflows/release.yml`. The workflow also accepts an optional `v` prefix. It verifies that the tag matches `package.json`, runs validation, builds the VSIX, and uploads it as a workflow artifact. Marketplace publishing then waits for approval through the `marketplace-publish` GitHub environment before it publishes that exact package.
+7. The workflow accepts semantic version tags such as `2.0.5` and also accepts an optional `v` prefix. It verifies that the tag matches `package.json`, runs validation, builds the VSIX, attaches it to the GitHub Release, and uploads it as a workflow artifact. Marketplace publishing then waits for approval through the `marketplace-publish` GitHub environment before it publishes that exact package.
 
 ### Marketplace Approval
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-group",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
# feat(release): attach VSIX packages to GitHub Releases

## Summary

Attach each validated release VSIX to its corresponding GitHub Release while retaining the existing Actions artifact and Marketplace approval flow.

### Changes

- Add a release-asset job that downloads the validated VSIX, creates a missing GitHub Release for pushed tags, and uploads the package as a release attachment.
- Document GitHub Release creation, automatic VSIX attachment, and the tag-push fallback; synchronize the lockfile release version with `3.0.0`.

### Checklist

- [x] Code follows project structure and conventions
- [ ] Unit tests added or updated
- [x] No secrets or sensitive data included
- [ ] The PR is labelled

### How to test

```bash
actionlint .github/workflows/release.yml
npx prettier --check .github/workflows/release.yml docs/development.md
```

Create a semantic version tag in a test repository or release branch and confirm that the workflow uploads `tab-group-<version>.vsix` to both the Actions artifact and the matching GitHub Release.

### Notes for reviewers

- The attachment job has job-scoped `contents: write`; Marketplace credentials remain available only in the protected publish job.
- Existing Releases created through GitHub's UI are reused, while tag-only releases are created automatically.
