### PR TITLE
feat: Support notebook diff tabs with stable IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Organize editor tabs into persistent, named groups from the Tab Group activity-b
 - Collapse and expand all groups.
 - Preserve group membership, order, names, colors, and collapsed state in workspace state.
 - Show an unsaved-file decoration for text editors.
+- Track text, text-diff, custom-editor, notebook, and notebook-diff tabs with stable IDs.
 
 ## Usage
 
@@ -22,6 +23,12 @@ Open the **Tab Group** activity-bar view. Drag tabs directly to group them. When
 ![Sorting grouped tabs](docs/sort.gif)
 
 Dropping an item onto another inserts it immediately before the target. In Sort Mode, dropping on the final slot appends it.
+
+## Tab support
+
+Tab Group supports the current public VS Code tab inputs that provide both a stable identity and a public reopen command: text editors, text diffs, custom editors, notebooks, and notebook diffs.
+
+Terminal and webview panel tabs are intentionally omitted. The public `TabInputTerminal` input has no identity fields, while `TabInputWebview` exposes only its view type. VS Code provides no public operation to match or reopen those individual instances, so adding them would merge unrelated tabs or break after a reload. Unknown and future tab inputs are skipped for the same reason.
 
 ## Development
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ npm run test:unit
 npm run test:e2e
 ```
 
-`test:unit` validates the grouping model without VS Code. `test:e2e` uses the locally installed VS Code application on macOS, then activates the extension and verifies its public commands are registered. Set `VSCODE_TEST_EXECUTABLE` to use a local executable on another platform. In CI it downloads and starts a clean VS Code Extension Development Host. Set `VSCODE_TEST_DOWNLOAD=true` to use the downloaded runtime locally. On headless Linux, run it through `xvfb-run -a npm run test:e2e`.
+`test:unit` validates the grouping model without VS Code. `test:e2e` uses the locally installed VS Code application on macOS, then activates the extension and verifies public commands, supported tab-input normalization, and rejection of opaque inputs. Set `VSCODE_TEST_EXECUTABLE` to use a local executable on another platform. In CI it downloads and starts a clean VS Code Extension Development Host. Set `VSCODE_TEST_DOWNLOAD=true` to use the downloaded runtime locally. On headless Linux, run it through `xvfb-run -a npm run test:e2e`.
 
 See [testing.md](testing.md) for the automated-check matrix and manual acceptance checklist.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,7 @@ npm run package
 | `npm run lint`      | TypeScript style and static analysis.                                     |
 | `npm run test:unit` | Grouping, ungrouping, lifecycle, and pure utility behavior.               |
 | `npm run compile`   | Strict TypeScript compilation.                                            |
-| `npm run test:e2e`  | Extension-host smoke test for activation and public command registration. |
+| `npm run test:e2e`  | Extension-host smoke test for activation, supported tab-input normalization, opaque-input rejection, and public command registration. |
 | `npm run package`   | Production VSIX build and package contents.                               |
 
 On macOS, `test:e2e` uses the installed VS Code application when available. Set `VSCODE_TEST_EXECUTABLE` to an executable path on another platform, or set `VSCODE_TEST_DOWNLOAD=true` to use a downloaded runtime. On headless Linux, run the command through `xvfb-run -a npm run test:e2e`.
@@ -68,6 +68,11 @@ Use `--skip-e2e` only when a local VS Code runtime is unavailable. CI and tag-ba
 
 - Modify an open text file without saving and confirm the unsaved decoration appears in the tree.
 - Save the file and confirm the decoration disappears.
+
+### Supported Tab Inputs
+
+- Confirm text editors, text diffs, custom editors, notebooks, and notebook diffs can be listed, grouped, selected, and reopened from the Tab Group view when their provider is available.
+- Confirm terminal and webview panel tabs are omitted because the public VS Code API does not expose a stable per-instance identity and reopen operation for them.
 
 ### Packaged Extension
 

--- a/src/providers/TabTypeHandler.ts
+++ b/src/providers/TabTypeHandler.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { setTabDecoration } from '../decorators/TabFileDecorationProvider';
 import { findLongestCommonFilePathPrefixIndex } from '../utils/filePath';
+import { getNormalizedNotebookDiffId } from '../utils/tabId';
 
 export type InputType = vscode.Tab['input'];
 
@@ -91,7 +92,7 @@ export function getHandler(
 
 /**
  * Register handler
- * Note: The order matters! Place more specifc handler before the general one. e.g. `TabInputReadmePreviewHandler`, then `TabInputWebviewHandler`
+ * Note: The order matters. Place more specific handlers before general ones.
  * @param ctor
  */
 function Registered(ctor: new () => TabTypeHandler<InputType>) {
@@ -184,6 +185,40 @@ export class TabInputTextDiffHandler implements TabTypeHandler<vscode.TabInputTe
 }
 
 @Registered
+export class TabInputNotebookDiffHandler implements TabTypeHandler<vscode.TabInputNotebookDiff> {
+  name = 'TabInputNotebookDiff';
+
+  is(tab: vscode.Tab): tab is TypedTab<vscode.TabInputNotebookDiff> {
+    return tab.input instanceof vscode.TabInputNotebookDiff;
+  }
+
+  getNormalizedId(tab: TypedTab<vscode.TabInputNotebookDiff>): string {
+    return getNormalizedNotebookDiffId(
+      tab.input.original,
+      tab.input.modified,
+      tab.input.notebookType,
+    );
+  }
+
+  createTreeItem(tab: TypedTab<vscode.TabInputNotebookDiff>): vscode.TreeItem {
+    const treeItem = new vscode.TreeItem(tab.input.modified);
+    treeItem.label = tab.label;
+    setTabDecoration(treeItem, tab.input.modified, 'diff');
+
+    return treeItem;
+  }
+
+  async openEditor(tab: TypedTab<vscode.TabInputNotebookDiff>): Promise<void> {
+    await vscode.commands
+      .executeCommand('vscode.diff', tab.input.original, tab.input.modified, tab.label, {
+        viewColumn: tab.group.viewColumn,
+      })
+      .then(undefined, e => console.error(e));
+    return;
+  }
+}
+
+@Registered
 export class TabInputCustomHandler implements TabTypeHandler<vscode.TabInputCustom> {
   name = 'TabInputCustom';
 
@@ -209,27 +244,6 @@ export class TabInputCustomHandler implements TabTypeHandler<vscode.TabInputCust
       })
       .then(undefined, e => console.error(e));
     return;
-  }
-}
-
-@Registered
-export class TabInputWebviewHandler implements TabTypeHandler<vscode.TabInputWebview> {
-  name = 'TabInputWebview';
-
-  is(tab: vscode.Tab): tab is TypedTab<vscode.TabInputWebview> {
-    return tab.input instanceof vscode.TabInputWebview;
-  }
-
-  getNormalizedId(tab: TypedTab<vscode.TabInputWebview>): string {
-    return tab.input.viewType;
-  }
-
-  createTreeItem(tab: TypedTab<vscode.TabInputWebview>): vscode.TreeItem {
-    return new vscode.TreeItem(tab.label);
-  }
-
-  async openEditor(_tab: TypedTab<vscode.TabInputWebview>): Promise<void> {
-    return Promise.resolve();
   }
 }
 

--- a/src/test/TreeState.test.ts
+++ b/src/test/TreeState.test.ts
@@ -74,6 +74,24 @@ describe('TreeState ungrouping', () => {
   });
 });
 
+describe('TreeState appending', () => {
+  test('appends a new tab to the root when a group exists', () => {
+    const group = createGroup('G');
+    const existingTab = createTab('A');
+    group.children = [existingTab];
+    existingTab.groupId = group.id;
+
+    const treeState = new TreeState();
+    treeState.setState([group]);
+    treeState.appendTab('B');
+
+    const appendedTab = treeState.getTab('B');
+    expect(appendedTab?.groupId).toBeNull();
+    expect(group.children).toEqual([existingTab]);
+    expect(treeState.getState()).toEqual([group, appendedTab]);
+  });
+});
+
 describe('TreeState group colors', () => {
   test('updates a persisted group color by group id', () => {
     const group = createGroup('G');

--- a/src/test/e2e/extension.test.ts
+++ b/src/test/e2e/extension.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { getHandler, getNormalizedTabId } from '../../providers/TabTypeHandler';
 
 suite('Tab Group extension', () => {
   test('activates and registers its tab-group commands', async () => {
@@ -14,5 +15,70 @@ suite('Tab Group extension', () => {
     assert.ok(commands.includes('tabsTreeView.group.changeColor'));
     assert.ok(commands.includes('tabsTreeView.enableSortMode'));
     assert.ok(commands.includes('tabsTreeView.reset'));
+  });
+
+  test('recognizes notebook editor tabs', async () => {
+    const extension = vscode.extensions.getExtension('jiapeiyao.tab-group');
+
+    assert.ok(extension, 'The Tab Group extension should be available to the extension host.');
+    await extension.activate();
+
+    const notebookType = 'jupyter-notebook';
+    const notebookUri = vscode.Uri.file('/workspace/example.ipynb');
+    const notebookTab = {
+      input: new vscode.TabInputNotebook(notebookUri, notebookType),
+    } as vscode.Tab;
+
+    assert.equal(
+      getNormalizedTabId(notebookTab),
+      JSON.stringify({ uri: notebookUri.path, notebookType }),
+    );
+  });
+
+  test('recognizes notebook diff editor tabs', async () => {
+    const extension = vscode.extensions.getExtension('jiapeiyao.tab-group');
+
+    assert.ok(extension, 'The Tab Group extension should be available to the extension host.');
+    await extension.activate();
+
+    const notebookType = 'jupyter-notebook';
+    const original = vscode.Uri.file('/workspace/original.ipynb');
+    const modified = vscode.Uri.file('/workspace/modified.ipynb');
+    const notebookDiffTab = {
+      input: new vscode.TabInputNotebookDiff(original, modified, notebookType),
+    } as vscode.Tab;
+    const normalizeUri = (uri: vscode.Uri) => ({
+      scheme: uri.scheme,
+      authority: uri.authority,
+      path: uri.path,
+      query: uri.query,
+      fragment: uri.fragment,
+    });
+
+    assert.equal(
+      getNormalizedTabId(notebookDiffTab),
+      JSON.stringify({
+        original: normalizeUri(original),
+        modified: normalizeUri(modified),
+        notebookType,
+      }),
+    );
+  });
+
+  test('skips tab inputs without a public identity or reopen operation', async () => {
+    const extension = vscode.extensions.getExtension('jiapeiyao.tab-group');
+
+    assert.ok(extension, 'The Tab Group extension should be available to the extension host.');
+    await extension.activate();
+
+    const webviewTab = {
+      input: new vscode.TabInputWebview('tab-group-test-webview'),
+    } as vscode.Tab;
+    const terminalTab = {
+      input: new vscode.TabInputTerminal(),
+    } as vscode.Tab;
+
+    assert.equal(getHandler(webviewTab), undefined);
+    assert.equal(getHandler(terminalTab), undefined);
   });
 });

--- a/src/test/tabId.test.ts
+++ b/src/test/tabId.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from '@jest/globals';
+import { getNormalizedNotebookDiffId } from '../utils/tabId';
+
+describe('tab IDs', () => {
+  test('keeps notebook diff resources and type distinct', () => {
+    const original = {
+      scheme: 'file',
+      authority: '',
+      path: '/workspace/original.ipynb',
+      query: 'version=1',
+      fragment: 'cell-1',
+    };
+    const modified = {
+      scheme: 'file',
+      authority: '',
+      path: '/workspace/modified.ipynb',
+      query: 'version=2',
+      fragment: 'cell-2',
+    };
+
+    expect(getNormalizedNotebookDiffId(original, modified, 'jupyter-notebook')).toBe(
+      JSON.stringify({
+        original,
+        modified,
+        notebookType: 'jupyter-notebook',
+      }),
+    );
+  });
+});

--- a/src/utils/tabId.ts
+++ b/src/utils/tabId.ts
@@ -1,0 +1,29 @@
+export interface TabUri {
+  readonly scheme: string;
+  readonly authority: string;
+  readonly path: string;
+  readonly query: string;
+  readonly fragment: string;
+}
+
+export function getNormalizedUri(uri: TabUri): TabUri {
+  return {
+    scheme: uri.scheme,
+    authority: uri.authority,
+    path: uri.path,
+    query: uri.query,
+    fragment: uri.fragment,
+  };
+}
+
+export function getNormalizedNotebookDiffId(
+  original: TabUri,
+  modified: TabUri,
+  notebookType: string,
+): string {
+  return JSON.stringify({
+    original: getNormalizedUri(original),
+    modified: getNormalizedUri(modified),
+    notebookType,
+  });
+}


### PR DESCRIPTION
<img width="328" height="277" alt="image" src="https://github.com/user-attachments/assets/315cc375-5472-4cb8-949c-30ca4e202710" />

# Support notebook diff tabs with stable IDs

## Summary

Add public-API-based support for notebook diff tabs and make unsupported opaque tab inputs explicit. Notebook diffs can now be tracked with stable persisted IDs, rendered in the Tab Group view, and reopened through VS Code's generic diff command.

### Changes

- Add `TabInputNotebookDiffHandler` and a normalized ID utility that preserves both notebook URIs and `notebookType`.
- Add unit and extension-host coverage for notebook and notebook-diff recognition, and verify that webview and terminal inputs are skipped.
- Preserve root-level tab placement with a `TreeState` regression test and document supported inputs and public API limitations.

### Checklist

- [x] Code follows project structure and conventions
- [x] Unit tests added or updated
- [x] No secrets or sensitive data included
- [x] The PR is labelled

### How to test

Run the validation suite:

- `npm run lint`
- `npm run test:unit` (13 tests passed)
- `npm run compile`
- `npm run test:e2e` (4 tests passed)
- `git diff --check`

For manual verification, open text, text-diff, custom-editor, notebook, and notebook-diff tabs, then confirm they can be listed, grouped, selected, and reopened from the Tab Group view.

### Notes for reviewers

- Terminal and webview tabs remain intentionally unsupported: public VS Code APIs do not expose stable per-instance identity and reopen operations for them, so tracking them could merge unrelated tabs or fail after reload.
- Notebook diffs reopen through `vscode.diff`; provider-specific notebook diff reopening was not independently verified with a contributed notebook type.
- Unknown and future tab inputs continue to be skipped when no reliable public identity and reopen path is available.

