### PR TITLE
feat: support recent tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Organize editor tabs into persistent, named groups from the Tab Group activity-b
 - Preserve group membership, order, names, colors, and collapsed state in workspace state.
 - Show an unsaved-file decoration for text editors.
 - Track text, text-diff, custom-editor, notebook, and notebook-diff tabs with stable IDs.
+- Show ungrouped tabs in a Recent Tabs view ordered by most recently viewed.
 
 ## Usage
 
@@ -22,7 +23,7 @@ Open the **Tab Group** activity-bar view. Drag tabs directly to group them. When
 
 ![Sorting grouped tabs](docs/sort.gif)
 
-Dropping an item onto another inserts it immediately before the target. In Sort Mode, dropping on the final slot appends it.
+Dropping an item onto another inserts it immediately before the target. In Sort Mode, dropping on the final slot appends it. The **Recent Tabs** view lists ungrouped tabs by most recent activation; drag a tab from it onto a group in the **Tabs** view to organize it.
 
 ## Tab support
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ npm run test:unit
 npm run test:e2e
 ```
 
-`test:unit` validates the grouping model without VS Code. `test:e2e` uses the locally installed VS Code application on macOS, then activates the extension and verifies public commands, supported tab-input normalization, and rejection of opaque inputs. Set `VSCODE_TEST_EXECUTABLE` to use a local executable on another platform. In CI it downloads and starts a clean VS Code Extension Development Host. Set `VSCODE_TEST_DOWNLOAD=true` to use the downloaded runtime locally. On headless Linux, run it through `xvfb-run -a npm run test:e2e`.
+`test:unit` validates the grouping model without VS Code. `test:e2e` uses the locally installed VS Code application on macOS, then activates the extension and verifies public commands, the Recent Tabs view, supported tab-input normalization, and rejection of opaque inputs. Set `VSCODE_TEST_EXECUTABLE` to use a local executable on another platform. In CI it downloads and starts a clean VS Code Extension Development Host. Set `VSCODE_TEST_DOWNLOAD=true` to use the downloaded runtime locally. On headless Linux, run it through `xvfb-run -a npm run test:e2e`.
 
 See [testing.md](testing.md) for the automated-check matrix and manual acceptance checklist.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,7 @@ npm run package
 | `npm run lint`      | TypeScript style and static analysis.                                     |
 | `npm run test:unit` | Grouping, ungrouping, lifecycle, and pure utility behavior.               |
 | `npm run compile`   | Strict TypeScript compilation.                                            |
-| `npm run test:e2e`  | Extension-host smoke test for activation, supported tab-input normalization, opaque-input rejection, and public command registration. |
+| `npm run test:e2e`  | Extension-host smoke test for activation, Recent Tabs contribution, supported tab-input normalization, opaque-input rejection, and public command registration. |
 | `npm run package`   | Production VSIX build and package contents.                               |
 
 On macOS, `test:e2e` uses the installed VS Code application when available. Set `VSCODE_TEST_EXECUTABLE` to an executable path on another platform, or set `VSCODE_TEST_DOWNLOAD=true` to use a downloaded runtime. On headless Linux, run the command through `xvfb-run -a npm run test:e2e`.
@@ -68,6 +68,12 @@ Use `--skip-e2e` only when a local VS Code runtime is unavailable. CI and tag-ba
 
 - Modify an open text file without saving and confirm the unsaved decoration appears in the tree.
 - Save the file and confirm the decoration disappears.
+
+### Recent Tabs
+
+- Open several ungrouped files and activate them in different orders; confirm **Recent Tabs** lists the most recently activated tab first.
+- Drag a tab from **Recent Tabs** onto an existing group and confirm it disappears from **Recent Tabs** after grouping.
+- Ungroup the tab and confirm it returns to **Recent Tabs** in its tracked position.
 
 ### Supported Tab Inputs
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
           "name": "Tabs",
           "icon": "media/icon.svg",
           "contextualTitle": "Tabs"
+        },
+        {
+          "id": "recentTabsTreeView",
+          "name": "Recent Tabs",
+          "icon": "media/icon.svg",
+          "contextualTitle": "Recent Tabs"
         }
       ]
     },
@@ -126,32 +132,32 @@
       "view/item/context": [
         {
           "command": "tabsTreeView.tab.ungroup",
-          "when": "view =~ /^tabsTreeView/ && viewItem == 'grouped-tab'",
+          "when": "view =~ /^(tabsTreeView|recentTabsTreeView)/ && viewItem == 'grouped-tab'",
           "group": "inline@0"
         },
         {
           "command": "tabsTreeView.tab.close",
-          "when": "view =~ /^tabsTreeView/ && viewItem =~ /tab/",
+          "when": "view =~ /^(tabsTreeView|recentTabsTreeView)/ && viewItem =~ /tab/",
           "group": "inline@1"
         },
         {
           "command": "tabsTreeView.group.rename",
-          "when": "view =~ /^tabsTreeView/ && viewItem == 'group'",
+          "when": "view =~ /^(tabsTreeView|recentTabsTreeView)/ && viewItem == 'group'",
           "group": "inline@0"
         },
         {
           "command": "tabsTreeView.group.changeColor",
-          "when": "view =~ /^tabsTreeView/ && viewItem == 'group'",
+          "when": "view =~ /^(tabsTreeView|recentTabsTreeView)/ && viewItem == 'group'",
           "group": "inline@1"
         },
         {
           "command": "tabsTreeView.group.cancelGroup",
-          "when": "view =~ /^tabsTreeView/ && viewItem == 'group'",
+          "when": "view =~ /^(tabsTreeView|recentTabsTreeView)/ && viewItem == 'group'",
           "group": "inline@2"
         },
         {
           "command": "tabsTreeView.group.close",
-          "when": "view =~ /^tabsTreeView/ && viewItem == 'group'",
+          "when": "view =~ /^(tabsTreeView|recentTabsTreeView)/ && viewItem == 'group'",
           "group": "inline@3"
         }
       ],

--- a/src/providers/RecentTabsTreeDataProvider.ts
+++ b/src/providers/RecentTabsTreeDataProvider.ts
@@ -47,10 +47,4 @@ export class RecentTabsTreeDataProvider
   ): Promise<void> {
     treeDataTransfer.set(TabDropMimeType, new vscode.DataTransferItem(source));
   }
-
-  async handleDrop(
-    _target: Tab | undefined,
-    _treeDataTransfer: vscode.DataTransfer,
-    _token: vscode.CancellationToken,
-  ): Promise<void> {}
 }

--- a/src/providers/RecentTabsTreeDataProvider.ts
+++ b/src/providers/RecentTabsTreeDataProvider.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode';
+import { Tab, isTab } from '../models/types';
+import { RecentTabs } from '../services/RecentTabs';
+import { Disposable } from '../utils/disposable';
+import { TabDropMimeType, TreeDataProvider } from './TreeDataProvider';
+
+export class RecentTabsTreeDataProvider
+  extends Disposable
+  implements vscode.TreeDataProvider<Tab>, vscode.TreeDragAndDropController<Tab>
+{
+  private readonly _onDidChangeTreeData = this._register(new vscode.EventEmitter<void>());
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  readonly dropMimeTypes: string[] = [];
+  readonly dragMimeTypes = [TabDropMimeType];
+
+  constructor(
+    private readonly treeDataProvider: TreeDataProvider,
+    private readonly recentTabs: RecentTabs,
+  ) {
+    super();
+  }
+
+  getChildren(element?: Tab): Tab[] {
+    if (element) {
+      return [];
+    }
+
+    const ungroupedTabs = this.treeDataProvider
+      .getState()
+      .filter((item): item is Tab => isTab(item) && item.groupId === null);
+    return this.recentTabs.sort(ungroupedTabs);
+  }
+
+  getTreeItem(tab: Tab): vscode.TreeItem {
+    return this.treeDataProvider.getTreeItem(tab);
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  async handleDrag(
+    source: Tab[],
+    treeDataTransfer: vscode.DataTransfer,
+    _token: vscode.CancellationToken,
+  ): Promise<void> {
+    treeDataTransfer.set(TabDropMimeType, new vscode.DataTransferItem(source));
+  }
+
+  async handleDrop(
+    _target: Tab | undefined,
+    _treeDataTransfer: vscode.DataTransfer,
+    _token: vscode.CancellationToken,
+  ): Promise<void> {}
+}

--- a/src/providers/TreeDataProvider.ts
+++ b/src/providers/TreeDataProvider.ts
@@ -26,6 +26,7 @@ export function getNativeTabs(tab: Tab): vscode.Tab[] {
 }
 
 export const TabDropMimeType = 'application/vnd.code.tree.tabstreeview';
+export const RecentTabsTreeMimeType = 'application/vnd.code.tree.recenttabstreeview';
 
 export class TreeDataProvider
   extends Disposable
@@ -55,8 +56,8 @@ export class TreeDataProvider
 
   private sortMode = false;
 
-  dropMimeTypes = [TabDropMimeType];
-  dragMimeTypes = ['text/uri-list'];
+  dropMimeTypes = [TabDropMimeType, RecentTabsTreeMimeType];
+  dragMimeTypes = [TabDropMimeType];
 
   getChildren(element?: Tab | Group): Array<Tab | Group | Slot> | null {
     const children = this.treeState.getChildren(element);
@@ -229,6 +230,7 @@ export class TreeDataProvider
   public setState(state: Array<Tab | Group>) {
     this.treeState.setState(state);
     this.triggerRerender();
+    this._onDidChangeState.fire();
   }
 
   public async activate(tab: Tab): Promise<any> {
@@ -330,7 +332,11 @@ export class TreeDataProvider
       const tabId = leafNode.id;
       const leafItem = this.getTreeItem(leafNode);
       const nativeTabs = getNativeTabs(leafNode);
-      if (nativeTabs[0].input instanceof vscode.TabInputText && leafItem.resourceUri) {
+      if (
+        nativeTabs.length > 0 &&
+        nativeTabs[0].input instanceof vscode.TabInputText &&
+        leafItem.resourceUri
+      ) {
         // use to update tab label if duplicated file name showing
         const filePathArray = leafItem.resourceUri.fsPath.split(sep);
         if (filePathArray.length > 1) {

--- a/src/providers/TreeDataProvider.ts
+++ b/src/providers/TreeDataProvider.ts
@@ -171,6 +171,9 @@ export class TreeDataProvider
     const draggeds: Array<Group | Tab> = (
       treeDataTransfer.get(TabDropMimeType)?.value ?? []
     ).filter((tab: any) => tab !== target);
+    if (draggeds.length === 0) {
+      return;
+    }
 
     if (this.sortMode) {
       this.doHandleSorting(target, draggeds);
@@ -229,8 +232,7 @@ export class TreeDataProvider
 
   public setState(state: Array<Tab | Group>) {
     this.treeState.setState(state);
-    this.triggerRerender();
-    this._onDidChangeState.fire();
+    this.triggerStateChange();
   }
 
   public async activate(tab: Tab): Promise<any> {
@@ -330,13 +332,13 @@ export class TreeDataProvider
     this.filePathTree = {};
     this.getLeafNodes(this.treeState.getState()).forEach((leafNode: Tab) => {
       const tabId = leafNode.id;
-      const leafItem = this.getTreeItem(leafNode);
       const nativeTabs = getNativeTabs(leafNode);
-      if (
-        nativeTabs.length > 0 &&
-        nativeTabs[0].input instanceof vscode.TabInputText &&
-        leafItem.resourceUri
-      ) {
+      if (nativeTabs.length === 0) {
+        return;
+      }
+
+      const leafItem = this.getTreeItem(leafNode);
+      if (nativeTabs[0].input instanceof vscode.TabInputText && leafItem.resourceUri) {
         // use to update tab label if duplicated file name showing
         const filePathArray = leafItem.resourceUri.fsPath.split(sep);
         if (filePathArray.length > 1) {

--- a/src/providers/TreeDataProvider.ts
+++ b/src/providers/TreeDataProvider.ts
@@ -25,6 +25,8 @@ export function getNativeTabs(tab: Tab): vscode.Tab[] {
   });
 }
 
+export const TabDropMimeType = 'application/vnd.code.tree.tabstreeview';
+
 export class TreeDataProvider
   extends Disposable
   implements
@@ -34,7 +36,6 @@ export class TreeDataProvider
   constructor() {
     super();
   }
-  private static TabDropMimeType = 'application/vnd.code.tree.tabstreeview';
   private _onDidChangeTreeData = this._register(new vscode.EventEmitter<void>());
   onDidChangeTreeData = this._onDidChangeTreeData.event;
   private _onDidChangeState = this._register(new vscode.EventEmitter<void>());
@@ -54,7 +55,7 @@ export class TreeDataProvider
 
   private sortMode = false;
 
-  dropMimeTypes = [TreeDataProvider.TabDropMimeType];
+  dropMimeTypes = [TabDropMimeType];
   dragMimeTypes = ['text/uri-list'];
 
   getChildren(element?: Tab | Group): Array<Tab | Group | Slot> | null {
@@ -156,7 +157,7 @@ export class TreeDataProvider
     _token: vscode.CancellationToken,
   ): Promise<void> {
     treeDataTransfer.set(
-      TreeDataProvider.TabDropMimeType,
+      TabDropMimeType,
       new vscode.DataTransferItem(source.filter(item => !isSlot(item))),
     );
   }
@@ -167,7 +168,7 @@ export class TreeDataProvider
     _token: vscode.CancellationToken,
   ) {
     const draggeds: Array<Group | Tab> = (
-      treeDataTransfer.get(TreeDataProvider.TabDropMimeType)?.value ?? []
+      treeDataTransfer.get(TabDropMimeType)?.value ?? []
     ).filter((tab: any) => tab !== target);
 
     if (this.sortMode) {

--- a/src/providers/TreeView.ts
+++ b/src/providers/TreeView.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
 import { getNormalizedTabId } from './TabTypeHandler';
 import { WorkspaceStateStore } from '../services/WorkspaceStateStore';
+import { RecentTabs } from '../services/RecentTabs';
 import { ExclusiveHandle } from '../utils/event';
 import { asPromise } from '../utils/async';
 import { Group, isGroup, Tab, TreeItemType } from '../models/types';
 import { getNativeTabs, TreeDataProvider } from './TreeDataProvider';
+import { RecentTabsTreeDataProvider } from './RecentTabsTreeDataProvider';
 import { Disposable } from '../utils/disposable';
 import { ContextKeys, setContext } from '../utils/context';
 import { getTabFileDecorationProvider } from '../decorators/TabFileDecorationProvider';
@@ -16,6 +18,10 @@ type GroupColorQuickPickItem = vscode.QuickPickItem & {
 
 export class TabsView extends Disposable {
   private treeDataProvider: TreeDataProvider = this._register(new TreeDataProvider());
+  private recentTabs = new RecentTabs();
+  private recentTabsTreeDataProvider = this._register(
+    new RecentTabsTreeDataProvider(this.treeDataProvider, this.recentTabs),
+  );
   private exclusiveHandle = new ExclusiveHandle();
   private selectedGroup: Group | undefined;
 
@@ -24,8 +30,10 @@ export class TabsView extends Disposable {
 
     const initialState = this.initializeState();
 
+    this.recentTabs.setState(this.workspaceStateStore.loadRecentTabs() ?? []);
     this.saveState(initialState);
     this.treeDataProvider.setState(initialState);
+    this.refreshRecentTabs(vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs));
 
     setContext(ContextKeys.AllCollapsed, this.treeDataProvider.isAllCollapsed());
     setContext(ContextKeys.SelectedGroup, false);
@@ -37,11 +45,19 @@ export class TabsView extends Disposable {
         canSelectMany: true,
       }),
     );
+    const recentView = this._register(
+      vscode.window.createTreeView('recentTabsTreeView', {
+        treeDataProvider: this.recentTabsTreeDataProvider,
+        dragAndDropController: this.recentTabsTreeDataProvider,
+        canSelectMany: true,
+      }),
+    );
 
     this._register(
-      this.treeDataProvider.onDidChangeState(() =>
-        this.saveState(this.treeDataProvider.getState()),
-      ),
+      this.treeDataProvider.onDidChangeState(() => {
+        this.saveState(this.treeDataProvider.getState());
+        this.recentTabsTreeDataProvider.refresh();
+      }),
     );
 
     const tabFileDecorationProvider = this._register(getTabFileDecorationProvider());
@@ -50,6 +66,7 @@ export class TabsView extends Disposable {
       tabFileDecorationProvider.onDidChangeFileDecorations(uris => {
         if (uris.length > 0) {
           this.treeDataProvider.triggerRerender();
+          this.recentTabsTreeDataProvider.refresh();
         }
       }),
     );
@@ -158,8 +175,18 @@ export class TabsView extends Disposable {
         }
 
         this.treeDataProvider.triggerRerender();
+        this.refreshRecentTabs([...e.opened, ...e.changed]);
         if (openedTabsChanged || closedTabsChanged) {
           this.saveState(this.treeDataProvider.getState());
+        }
+      }),
+    );
+
+    this._register(
+      recentView.onDidChangeSelection(e => {
+        const item = e.selection.length > 0 ? e.selection[e.selection.length - 1] : undefined;
+        if (item?.type === TreeItemType.Tab) {
+          this.exclusiveHandle.run(() => asPromise(this.treeDataProvider.activate(item)));
         }
       }),
     );
@@ -266,6 +293,47 @@ export class TabsView extends Disposable {
 
   private saveState(state: Array<Tab | Group>): void {
     void this.workspaceStateStore.save(state);
+  }
+
+  private saveRecentTabs(): void {
+    void this.workspaceStateStore.saveRecentTabs(this.recentTabs.getState());
+  }
+
+  private refreshRecentTabs(tabsToTouch: readonly vscode.Tab[] = []): void {
+    const nativeTabs = vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs);
+    const nativeTabIds: string[] = [];
+    nativeTabs.forEach(nativeTab => {
+      try {
+        const tabId = getNormalizedTabId(nativeTab);
+        if (!nativeTabIds.includes(tabId)) {
+          nativeTabIds.push(tabId);
+        }
+      } catch {
+        // skip unsupported tab inputs
+      }
+    });
+
+    let changed = this.recentTabs.reconcile(nativeTabIds);
+    const nativeTabIdSet = new Set(nativeTabIds);
+    tabsToTouch.forEach(nativeTab => {
+      if (!nativeTab.isActive) {
+        return;
+      }
+
+      try {
+        const tabId = getNormalizedTabId(nativeTab);
+        if (nativeTabIdSet.has(tabId)) {
+          changed = this.recentTabs.touch(tabId) || changed;
+        }
+      } catch {
+        // skip unsupported tab inputs
+      }
+    });
+
+    if (changed) {
+      this.saveRecentTabs();
+      this.recentTabsTreeDataProvider.refresh();
+    }
   }
 
   private isCorrespondingTab(tab: vscode.Tab, jsonTab: Tab): boolean {

--- a/src/providers/TreeView.ts
+++ b/src/providers/TreeView.ts
@@ -33,7 +33,7 @@ export class TabsView extends Disposable {
     this.recentTabs.setState(this.workspaceStateStore.loadRecentTabs() ?? []);
     this.saveState(initialState);
     this.treeDataProvider.setState(initialState);
-    this.refreshRecentTabs(vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs));
+    this.refreshRecentTabs(this.getActiveNativeTab());
 
     setContext(ContextKeys.AllCollapsed, this.treeDataProvider.isAllCollapsed());
     setContext(ContextKeys.SelectedGroup, false);
@@ -133,12 +133,8 @@ export class TabsView extends Disposable {
       vscode.commands.registerCommand('tabsTreeView.reset', () => {
         this.selectedGroup = undefined;
         setContext(ContextKeys.SelectedGroup, false);
-        const initialState = this.mergeState(
-          [],
-          vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs),
-        );
+        const initialState = this.mergeState([], this.getNativeTabs());
         this.treeDataProvider.setState(initialState);
-        this.saveState(initialState);
       }),
     );
 
@@ -175,10 +171,16 @@ export class TabsView extends Disposable {
         }
 
         this.treeDataProvider.triggerRerender();
-        this.refreshRecentTabs([...e.opened, ...e.changed]);
+        this.refreshRecentTabs(this.getActiveNativeTab());
         if (openedTabsChanged || closedTabsChanged) {
           this.saveState(this.treeDataProvider.getState());
         }
+      }),
+    );
+
+    this._register(
+      vscode.window.tabGroups.onDidChangeTabGroups(() => {
+        this.refreshRecentTabs(this.getActiveNativeTab());
       }),
     );
 
@@ -244,8 +246,7 @@ export class TabsView extends Disposable {
 
   private initializeState(): Array<Tab | Group> {
     const jsonItems = this.workspaceStateStore.load() ?? [];
-    const nativeTabs = vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs);
-    return this.mergeState(jsonItems, nativeTabs);
+    return this.mergeState(jsonItems, this.getNativeTabs());
   }
 
   private mergeState(jsonItems: Array<Tab | Group>, nativeTabs: vscode.Tab[]): Array<Tab | Group> {
@@ -296,44 +297,50 @@ export class TabsView extends Disposable {
   }
 
   private saveRecentTabs(): void {
-    void this.workspaceStateStore.saveRecentTabs(this.recentTabs.getState());
+    void this.workspaceStateStore
+      .saveRecentTabs(this.recentTabs.getState())
+      .then(undefined, error => console.error('Failed to save recent tabs', error));
   }
 
-  private refreshRecentTabs(tabsToTouch: readonly vscode.Tab[] = []): void {
-    const nativeTabs = vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs);
-    const nativeTabIds: string[] = [];
-    nativeTabs.forEach(nativeTab => {
-      try {
-        const tabId = getNormalizedTabId(nativeTab);
-        if (!nativeTabIds.includes(tabId)) {
-          nativeTabIds.push(tabId);
-        }
-      } catch {
-        // skip unsupported tab inputs
-      }
-    });
+  private refreshRecentTabs(activeTab: vscode.Tab | undefined): void {
+    const nativeTabIds = this.collectNativeTabIds(this.getNativeTabs());
 
-    let changed = this.recentTabs.reconcile(nativeTabIds);
-    const nativeTabIdSet = new Set(nativeTabIds);
-    tabsToTouch.forEach(nativeTab => {
-      if (!nativeTab.isActive) {
-        return;
-      }
-
+    let changed = this.recentTabs.reconcile([...nativeTabIds]);
+    if (activeTab) {
       try {
-        const tabId = getNormalizedTabId(nativeTab);
-        if (nativeTabIdSet.has(tabId)) {
+        const tabId = getNormalizedTabId(activeTab);
+        if (nativeTabIds.has(tabId)) {
           changed = this.recentTabs.touch(tabId) || changed;
         }
       } catch {
         // skip unsupported tab inputs
       }
-    });
+    }
 
     if (changed) {
       this.saveRecentTabs();
       this.recentTabsTreeDataProvider.refresh();
     }
+  }
+
+  private getNativeTabs(): vscode.Tab[] {
+    return vscode.window.tabGroups.all.flatMap(tabGroup => tabGroup.tabs);
+  }
+
+  private getActiveNativeTab(): vscode.Tab | undefined {
+    return vscode.window.tabGroups.activeTabGroup?.activeTab;
+  }
+
+  private collectNativeTabIds(nativeTabs: readonly vscode.Tab[]): Set<string> {
+    const nativeTabIds = new Set<string>();
+    nativeTabs.forEach(nativeTab => {
+      try {
+        nativeTabIds.add(getNormalizedTabId(nativeTab));
+      } catch {
+        // skip unsupported tab inputs
+      }
+    });
+    return nativeTabIds;
   }
 
   private isCorrespondingTab(tab: vscode.Tab, jsonTab: Tab): boolean {

--- a/src/services/RecentTabs.ts
+++ b/src/services/RecentTabs.ts
@@ -1,0 +1,57 @@
+import { Tab } from '../models/types';
+
+export class RecentTabs {
+  private tabIds: string[] = [];
+
+  constructor(tabIds: readonly string[] = []) {
+    this.setState(tabIds);
+  }
+
+  public setState(tabIds: readonly string[]): void {
+    this.tabIds = [];
+    tabIds.forEach(tabId => {
+      if (!this.tabIds.includes(tabId)) {
+        this.tabIds.push(tabId);
+      }
+    });
+  }
+
+  public getState(): string[] {
+    return this.tabIds.slice();
+  }
+
+  public touch(tabId: string): boolean {
+    if (this.tabIds[0] === tabId) {
+      return false;
+    }
+
+    this.tabIds = [tabId, ...this.tabIds.filter(existingTabId => existingTabId !== tabId)];
+    return true;
+  }
+
+  public reconcile(tabIds: readonly string[]): boolean {
+    const validTabIds = new Set(tabIds);
+    const reconciledTabIds = this.tabIds.filter(tabId => validTabIds.has(tabId));
+
+    tabIds.forEach(tabId => {
+      if (!reconciledTabIds.includes(tabId)) {
+        reconciledTabIds.push(tabId);
+      }
+    });
+
+    const changed =
+      reconciledTabIds.length !== this.tabIds.length ||
+      reconciledTabIds.some((tabId, index) => tabId !== this.tabIds[index]);
+    this.tabIds = reconciledTabIds;
+    return changed;
+  }
+
+  public sort(tabs: readonly Tab[]): Tab[] {
+    const tabIndex = new Map(this.tabIds.map((tabId, index) => [tabId, index]));
+    return tabs.slice().sort((leftTab, rightTab) => {
+      const leftIndex = tabIndex.get(leftTab.id) ?? this.tabIds.length;
+      const rightIndex = tabIndex.get(rightTab.id) ?? this.tabIds.length;
+      return leftIndex - rightIndex;
+    });
+  }
+}

--- a/src/services/RecentTabs.ts
+++ b/src/services/RecentTabs.ts
@@ -8,12 +8,7 @@ export class RecentTabs {
   }
 
   public setState(tabIds: readonly string[]): void {
-    this.tabIds = [];
-    tabIds.forEach(tabId => {
-      if (!this.tabIds.includes(tabId)) {
-        this.tabIds.push(tabId);
-      }
-    });
+    this.tabIds = [...new Set(tabIds)];
   }
 
   public getState(): string[] {
@@ -32,10 +27,12 @@ export class RecentTabs {
   public reconcile(tabIds: readonly string[]): boolean {
     const validTabIds = new Set(tabIds);
     const reconciledTabIds = this.tabIds.filter(tabId => validTabIds.has(tabId));
+    const knownTabIds = new Set(reconciledTabIds);
 
     tabIds.forEach(tabId => {
-      if (!reconciledTabIds.includes(tabId)) {
+      if (!knownTabIds.has(tabId)) {
         reconciledTabIds.push(tabId);
+        knownTabIds.add(tabId);
       }
     });
 

--- a/src/services/WorkspaceStateStore.ts
+++ b/src/services/WorkspaceStateStore.ts
@@ -1,5 +1,66 @@
 import * as vscode from 'vscode';
-import { Group, Tab } from '../models/types';
+import { Group, Tab, TreeItemType } from '../models/types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isTabValue(value: unknown): value is Tab {
+  return (
+    isRecord(value) &&
+    value.type === TreeItemType.Tab &&
+    isValidId(value.id) &&
+    (value.groupId === null || isValidId(value.groupId))
+  );
+}
+
+function isGroupValue(value: unknown): value is Group {
+  return (
+    isRecord(value) &&
+    value.type === TreeItemType.Group &&
+    isValidId(value.id) &&
+    typeof value.colorId === 'string' &&
+    typeof value.label === 'string' &&
+    typeof value.collapsed === 'boolean' &&
+    Array.isArray(value.children) &&
+    value.children.every(isTabValue)
+  );
+}
+
+function isValidState(value: unknown): value is Array<Tab | Group> {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  const ids = new Set<string>();
+  for (const item of value) {
+    if (isTabValue(item)) {
+      if (item.groupId !== null || ids.has(item.id)) {
+        return false;
+      }
+      ids.add(item.id);
+      continue;
+    }
+
+    if (!isGroupValue(item) || ids.has(item.id)) {
+      return false;
+    }
+
+    ids.add(item.id);
+    for (const child of item.children) {
+      if (child.groupId !== item.id || ids.has(child.id)) {
+        return false;
+      }
+      ids.add(child.id);
+    }
+  }
+
+  return true;
+}
 
 export class WorkspaceStateStore {
   private static readonly stateKey = 'tabs.workspace.state.key';
@@ -8,7 +69,8 @@ export class WorkspaceStateStore {
   constructor(private readonly workspaceState: vscode.Memento) {}
 
   load(): Array<Tab | Group> | undefined {
-    return this.workspaceState.get<Array<Tab | Group>>(WorkspaceStateStore.stateKey);
+    const value = this.workspaceState.get<unknown>(WorkspaceStateStore.stateKey);
+    return isValidState(value) ? value : undefined;
   }
 
   save(state: Array<Tab | Group>): Thenable<void> {
@@ -16,7 +78,12 @@ export class WorkspaceStateStore {
   }
 
   loadRecentTabs(): string[] | undefined {
-    return this.workspaceState.get<string[]>(WorkspaceStateStore.recentTabsStateKey);
+    const value = this.workspaceState.get<unknown>(WorkspaceStateStore.recentTabsStateKey);
+    if (!Array.isArray(value)) {
+      return undefined;
+    }
+
+    return value.filter((tabId): tabId is string => typeof tabId === 'string');
   }
 
   saveRecentTabs(tabIds: readonly string[]): Thenable<void> {

--- a/src/services/WorkspaceStateStore.ts
+++ b/src/services/WorkspaceStateStore.ts
@@ -3,6 +3,7 @@ import { Group, Tab } from '../models/types';
 
 export class WorkspaceStateStore {
   private static readonly stateKey = 'tabs.workspace.state.key';
+  private static readonly recentTabsStateKey = 'tabs.workspace.recent-tabs.key';
 
   constructor(private readonly workspaceState: vscode.Memento) {}
 
@@ -12,5 +13,13 @@ export class WorkspaceStateStore {
 
   save(state: Array<Tab | Group>): Thenable<void> {
     return this.workspaceState.update(WorkspaceStateStore.stateKey, state);
+  }
+
+  loadRecentTabs(): string[] | undefined {
+    return this.workspaceState.get<string[]>(WorkspaceStateStore.recentTabsStateKey);
+  }
+
+  saveRecentTabs(tabIds: readonly string[]): Thenable<void> {
+    return this.workspaceState.update(WorkspaceStateStore.recentTabsStateKey, [...tabIds]);
   }
 }

--- a/src/test/RecentTabs.test.ts
+++ b/src/test/RecentTabs.test.ts
@@ -12,7 +12,7 @@ function createTab(id: string): Tab {
 
 describe('RecentTabs', () => {
   test('moves a viewed tab to the front once', () => {
-    const recentTabs = new RecentTabs(['first', 'second']);
+    const recentTabs = new RecentTabs(['first', 'first', 'second']);
 
     expect(recentTabs.touch('second')).toBe(true);
     expect(recentTabs.touch('second')).toBe(false);

--- a/src/test/RecentTabs.test.ts
+++ b/src/test/RecentTabs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from '@jest/globals';
+import { Tab, TreeItemType } from '../models/types';
+import { RecentTabs } from '../services/RecentTabs';
+
+function createTab(id: string): Tab {
+  return {
+    type: TreeItemType.Tab,
+    groupId: null,
+    id,
+  };
+}
+
+describe('RecentTabs', () => {
+  test('moves a viewed tab to the front once', () => {
+    const recentTabs = new RecentTabs(['first', 'second']);
+
+    expect(recentTabs.touch('second')).toBe(true);
+    expect(recentTabs.touch('second')).toBe(false);
+    expect(recentTabs.getState()).toEqual(['second', 'first']);
+  });
+
+  test('removes closed tabs and appends newly discovered tabs', () => {
+    const recentTabs = new RecentTabs(['first', 'closed']);
+
+    expect(recentTabs.reconcile(['first', 'new'])).toBe(true);
+    expect(recentTabs.getState()).toEqual(['first', 'new']);
+  });
+
+  test('sorts tabs by recency and keeps unknown tabs last', () => {
+    const recentTabs = new RecentTabs(['second', 'first']);
+
+    expect(recentTabs.sort([createTab('new'), createTab('first'), createTab('second')])).toEqual([
+      createTab('second'),
+      createTab('first'),
+      createTab('new'),
+    ]);
+  });
+});

--- a/src/test/WorkspaceStateStore.test.ts
+++ b/src/test/WorkspaceStateStore.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import type { Memento } from 'vscode';
+import { TreeItemType } from '../models/types';
+import { WorkspaceStateStore } from '../services/WorkspaceStateStore';
+
+function createStore(value: unknown): WorkspaceStateStore {
+  const workspaceState = {
+    get: jest.fn().mockReturnValue(value),
+  } as unknown as Memento;
+  return new WorkspaceStateStore(workspaceState);
+}
+
+describe('WorkspaceStateStore', () => {
+  test('loads a valid main state', () => {
+    const state = [
+      {
+        type: TreeItemType.Group,
+        id: 'group',
+        colorId: 'charts.blue',
+        label: 'Group',
+        children: [{ type: TreeItemType.Tab, groupId: 'group', id: 'first' }],
+        collapsed: false,
+      },
+      { type: TreeItemType.Tab, groupId: null, id: 'second' },
+    ];
+
+    expect(createStore(state).load()).toEqual(state);
+  });
+
+  test('ignores a non-array main state value', () => {
+    expect(
+      createStore({ type: TreeItemType.Tab, groupId: null, id: 'first' }).load(),
+    ).toBeUndefined();
+  });
+
+  test('rejects malformed main state items', () => {
+    expect(createStore([{ type: TreeItemType.Tab, groupId: 'group' }]).load()).toBeUndefined();
+    expect(
+      createStore([
+        {
+          type: TreeItemType.Group,
+          id: 'group',
+          colorId: 'charts.blue',
+          label: 'Group',
+          children: {},
+          collapsed: false,
+        },
+      ]).load(),
+    ).toBeUndefined();
+  });
+
+  test('rejects duplicate or inconsistent persisted IDs', () => {
+    expect(
+      createStore([
+        { type: TreeItemType.Tab, groupId: null, id: 'first' },
+        { type: TreeItemType.Tab, groupId: null, id: 'first' },
+      ]).load(),
+    ).toBeUndefined();
+    expect(
+      createStore([
+        {
+          type: TreeItemType.Group,
+          id: 'group',
+          colorId: 'charts.blue',
+          label: 'Group',
+          children: [{ type: TreeItemType.Tab, groupId: null, id: 'first' }],
+          collapsed: false,
+        },
+      ]).load(),
+    ).toBeUndefined();
+  });
+
+  test('filters invalid recent tab entries at the storage boundary', () => {
+    expect(createStore(['first', 42, null, 'second']).loadRecentTabs()).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+
+  test('ignores a non-array recent tab value', () => {
+    expect(createStore({ tabId: 'first' }).loadRecentTabs()).toBeUndefined();
+  });
+});

--- a/src/test/e2e/extension.test.ts
+++ b/src/test/e2e/extension.test.ts
@@ -15,6 +15,12 @@ suite('Tab Group extension', () => {
     assert.ok(commands.includes('tabsTreeView.group.changeColor'));
     assert.ok(commands.includes('tabsTreeView.enableSortMode'));
     assert.ok(commands.includes('tabsTreeView.reset'));
+
+    const contributedViews = extension.packageJSON.contributes.views.tabs as Array<{ id: string }>;
+    assert.ok(
+      contributedViews.some(view => view.id === 'recentTabsTreeView'),
+      'The Recent Tabs view should be contributed.',
+    );
   });
 
   test('recognizes notebook editor tabs', async () => {

--- a/src/test/e2e/extension.test.ts
+++ b/src/test/e2e/extension.test.ts
@@ -1,6 +1,14 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { Group, isGroup, Tab, TreeItemType } from '../../models/types';
 import { getHandler, getNormalizedTabId } from '../../providers/TabTypeHandler';
+import { RecentTabsTreeDataProvider } from '../../providers/RecentTabsTreeDataProvider';
+import {
+  RecentTabsTreeMimeType,
+  TabDropMimeType,
+  TreeDataProvider,
+} from '../../providers/TreeDataProvider';
+import { RecentTabs } from '../../services/RecentTabs';
 
 suite('Tab Group extension', () => {
   test('activates and registers its tab-group commands', async () => {
@@ -39,6 +47,50 @@ suite('Tab Group extension', () => {
       getNormalizedTabId(notebookTab),
       JSON.stringify({ uri: notebookUri.path, notebookType }),
     );
+  });
+
+  test('uses one drag payload contract for both tab views', () => {
+    const treeDataProvider = new TreeDataProvider();
+    const recentTabsTreeDataProvider = new RecentTabsTreeDataProvider(
+      treeDataProvider,
+      new RecentTabs(),
+    );
+
+    assert.deepStrictEqual(treeDataProvider.dragMimeTypes, [TabDropMimeType]);
+    assert.deepStrictEqual(treeDataProvider.dropMimeTypes, [
+      TabDropMimeType,
+      RecentTabsTreeMimeType,
+    ]);
+    assert.deepStrictEqual(recentTabsTreeDataProvider.dragMimeTypes, [TabDropMimeType]);
+    assert.deepStrictEqual(recentTabsTreeDataProvider.dropMimeTypes, []);
+
+    recentTabsTreeDataProvider.dispose();
+    treeDataProvider.dispose();
+  });
+
+  test('accepts a Recent Tabs drag payload in the main tree', async () => {
+    const treeDataProvider = new TreeDataProvider();
+    const recentTabsTreeDataProvider = new RecentTabsTreeDataProvider(
+      treeDataProvider,
+      new RecentTabs(),
+    );
+    const target: Tab = { type: TreeItemType.Tab, groupId: null, id: 'target' };
+    const source: Tab = { type: TreeItemType.Tab, groupId: null, id: 'source' };
+    const cancellation = new vscode.CancellationTokenSource();
+
+    treeDataProvider.setState([target, source]);
+    const dataTransfer = new vscode.DataTransfer();
+    await recentTabsTreeDataProvider.handleDrag([source], dataTransfer, cancellation.token);
+    await treeDataProvider.handleDrop(target, dataTransfer, cancellation.token);
+
+    const state = treeDataProvider.getState();
+    assert.equal(state.length, 1);
+    assert.equal(isGroup(state[0]), true);
+    assert.deepStrictEqual((state[0] as Group).children, [target, source]);
+
+    cancellation.dispose();
+    recentTabsTreeDataProvider.dispose();
+    treeDataProvider.dispose();
   });
 
   test('recognizes notebook diff editor tabs', async () => {


### PR DESCRIPTION
# Feature/support recent tabs

## Summary

Adds a persisted Recent Tabs view for ungrouped tabs, keeps its order synchronized with native tab activation and group changes, and supports moving entries into the main Tabs view. The change also validates restored workspace data and documents the new workflow.

### Changes

- Adds Recent Tabs ordering and persistence through a read-only tree contribution.
- Refreshes Recent Tabs on tab changes, supports selecting, closing, ungrouping, and dragging tabs into the main tree.
- Extends tree drag/drop MIME registration and guards no-op drops.
- Validates persisted group and tab records and filters invalid Recent Tabs IDs.
- Adds unit and extension-host coverage plus README, development, and testing documentation updates.

### Checklist

- [x] Code follows project structure and conventions
- [x] Unit tests added or updated
- [x] No secrets or sensitive data included
- [x] The PR is labelled

### How to test

- Run `npm run test:unit` for unit coverage.
- Run `npm run compile` for strict TypeScript compilation.
- Run `npm run test:e2e` for extension-host coverage.
- Manually open and activate ungrouped files, verify **Recent Tabs** ordering, drag one into a group, then ungroup it and confirm it returns to the list.

### Notes for reviewers

- Target branch: `main`.
- `npm run test:e2e` passes all 6 extension-host tests, and the new Recent Tabs and workspace-state suites pass.
- Full lint and unit runs are currently blocked by the empty [src/test/event.test.ts](src/test/event.test.ts) file in the branch: Prettier rejects its blank line and Jest reports that it contains no tests.
